### PR TITLE
fix: remove magneticVariation from RMC sentence

### DIFF
--- a/sentences/RMC.js
+++ b/sentences/RMC.js
@@ -32,11 +32,11 @@ module.exports = function (app) {
       'navigation.datetime',
       'navigation.speedOverGround',
       'navigation.courseOverGroundTrue',
-      'navigation.position'
-      //'navigation.magneticVariation'
+      'navigation.position',
+      'navigation.magneticVariation'
     ],
-    defaults: ['', undefined, undefined, undefined],
-    f: function (datetime8601, sog, cog, position) {
+    defaults: ['', undefined, undefined, undefined, 0.0],
+    f: function (datetime8601, sog, cog, position, magneticVariation) {
       let time = ''
       let date = ''
       if (datetime8601.length > 0) {
@@ -50,6 +50,11 @@ module.exports = function (app) {
         let year = ('00' + datetime.getUTCFullYear()).slice(-2)
         time = hours + minutes + seconds
         date = day + month + year
+      }
+      var magneticVariationDir = 'E'
+      if ( magneticVariation < 0 ) {
+        magneticVariationDir = 'W';
+        magneticVariation = magneticVariation * -1;
       }
       return toSentence([
         '$SKRMC',
@@ -67,8 +72,8 @@ module.exports = function (app) {
         radsToDeg(cog).toFixed(1),
         date,
         // We submit a Magnetic Variation of 0.
-        '0.0',
-        'E'
+        magneticVariation.toFixed(1),
+        magneticVariationDir
       ])
     }
   }

--- a/sentences/RMC.js
+++ b/sentences/RMC.js
@@ -32,8 +32,8 @@ module.exports = function (app) {
       'navigation.datetime',
       'navigation.speedOverGround',
       'navigation.courseOverGroundTrue',
-      'navigation.position',
-      'navigation.magneticVariation'
+      'navigation.position'
+      //'navigation.magneticVariation'
     ],
     defaults: ['', undefined, undefined, undefined],
     f: function (datetime8601, sog, cog, position) {

--- a/test/RMC.js
+++ b/test/RMC.js
@@ -7,7 +7,8 @@ describe('RMC', function () {
         'navigation.speedOverGround': new Bacon.Bus(),
         'navigation.courseOverGroundTrue': new Bacon.Bus(),
         'navigation.datetime': new Bacon.Bus(),
-        'navigation.position': new Bacon.Bus()
+        'navigation.position': new Bacon.Bus(),
+        'navigation.magneticVariation': new Bacon.Bus()
     }
     const app = {
       streambundle: { getSelfStream: path => streams[path] },


### PR DESCRIPTION
position.magneticVariation was not being used at all and since there is no default RMC messages were not getting sent when there is no position.magneticVariation data.