### PR TITLE
Fix: RMC output fails where degrees longitude > 99

### DIFF
--- a/nmea.js
+++ b/nmea.js
@@ -62,12 +62,67 @@ function padd (n, p, c) {
   return (pad + n).slice(-pad.length)
 }
 
-function toNmeaDegrees (inVal) {
-  let val = Math.abs(inVal)
-  let minutes = Math.floor(val)
-  let minutes_decimal = val % 1
-  minutes_decimal *= 60.0
-  return padd(minutes.toFixed(0), 2) + padd(minutes_decimal.toFixed(4), 7)
+function decimalDegreesToDegreesAndDecimalMinutes ( degrees ) {
+  /*
+    decimalDegreesToDegreesAndDecimalMinutes takes a float (degrees)
+    representing decimal degrees and returns a tuple [deg, min, dir], where
+    deg is an int representing degrees, min is a float representing decimal
+    minutes and dir is a positive or negative integer representing the
+    direction from the origin ( +1 for N and E, -1 for S and W )
+
+    NOTE: 0 degrees is N or E
+  */
+
+  let dir=1 // default to N or E
+
+  if (degrees<0) {
+    dir = -1
+    degrees *= -1
+  }
+
+  let degrees_out = Math.floor(degrees)
+  let minutes = (degrees % 1) * 60
+  return [ degrees_out, minutes, dir ]
+}
+
+function toNmeaDegreesLatitude (inVal) {
+  /*
+    toNmeaDegreesLatitude takes a float (inVal) representing decimal degrees
+    and returns a string formatted as degrees and decimal minutes suitable for
+    use in an NMEA0183 sentence. (e.g. DDMM.MMMM)
+  */
+
+  if (typeof inVal != 'number' || inVal < -90 || inVal > 90) {
+    throw new Error("invalid input to toNmeaDegreesLatitude: " + inVal)
+  }
+
+  let [degrees, minutes, dir] = decimalDegreesToDegreesAndDecimalMinutes(inVal)
+
+  return(
+      padd(degrees.toFixed(0), 2)
+      + padd(minutes.toFixed(4), 7)
+      + "," + (dir > 0 ? "N" : "S")
+    )
+}
+
+function toNmeaDegreesLongitude (inVal) {
+  /*
+    toNmeaDegreesLongitude takes a float (inVal) representing decimal degrees
+    and returns a string formatted as degrees and decimal minutes suitable for
+    use in an NMEA0183 sentence. (e.g. DDDMM.MMMM)
+  */
+
+  if (typeof inVal != 'number' || inVal <= -180 || inVal > 180) {
+    throw new Error("invalid input to toNmeaDegreesLongitude: " + inVal)
+  }
+
+  let [degrees, minutes, dir] = decimalDegreesToDegreesAndDecimalMinutes(inVal)
+
+  return(
+      padd(degrees.toFixed(0), 3)
+      + padd(minutes.toFixed(4), 7)
+      + "," + (dir > 0 ? "E" : "W")
+    )
 }
 
 function fixAngle (d) {
@@ -82,6 +137,7 @@ module.exports = {
   radsToDeg: radsToDeg,
   msToKnots: msToKnots,
   msToKM: msToKM,
-  toNmeaDegrees: toNmeaDegrees,
+  toNmeaDegreesLatitude: toNmeaDegreesLatitude,
+  toNmeaDegreesLongitude: toNmeaDegreesLongitude,
   fixAngle: fixAngle
 }

--- a/sentences/GLL.js
+++ b/sentences/GLL.js
@@ -20,10 +20,8 @@ module.exports = function (app) {
       var seconds = ('00' + datetime.getSeconds()).slice(-2)
       return nmea.toSentence([
         '$IIGLL',
-        nmea.toNmeaDegrees(position.latitude),
-        position.latitude < 0 ? 'S' : 'N',
-        nmea.toNmeaDegrees(position.longitude),
-        position.longitude < 0 ? 'W' : 'E',
+        nmea.toNmeaDegreesLatitude(position.latitude),
+        nmea.toNmeaDegreesLongitude(position.longitude),
         hours + minutes + seconds + '.020',
         'A'
       ])

--- a/sentences/RMB.js
+++ b/sentences/RMB.js
@@ -32,10 +32,8 @@ module.exports = function (app) {
         '$IIRMB',
         crossTrackError.toFixed(2),
         crossTrackError < 0 ? 'R' : 'L',
-        nmea.toNmeaDegrees(wpLatitude),
-        wpLatitude < 0 ? 'S' : 'N',
-        nmea.toNmeaDegrees(wpLongitude),
-        wpLongitude < 0 ? 'W' : 'E',
+        nmea.toNmeaDegreesLatitude(wpLatitude),
+        nmea.toNmeaDegreesLongitude(wpLongitude),
         wpDistance.toFixed(2),
         nmea.radsToDeg(bearingTrue).toFixed(2),
         'V', // dont set the arrival flag as it will set of alarms.

--- a/sentences/RMC.js
+++ b/sentences/RMC.js
@@ -24,7 +24,7 @@
 // This needs to run faster that others.
 
 // NMEA0183 Encoder RMC   $INRMC,200152.020,A,5943.2980,N,2444.1043,E,6.71,194.30,0000,8.1,E*40
-const { toSentence, toNmeaDegrees, radsToDeg } = require('../nmea.js')
+const { toSentence, toNmeaDegreesLatitude, toNmeaDegreesLongitude, radsToDeg } = require('../nmea.js')
 module.exports = function (app) {
   return {
     title: 'RMC - GPS recommended minimum',
@@ -60,14 +60,8 @@ module.exports = function (app) {
         '$SKRMC',
         time,
         'A',
-        // Force 4 digits before decimal point and 4 digits after
-        ('0000' + (toNmeaDegrees(position.latitude) * 1).toFixed(4)).slice(-9),
-        position.latitude < 0 ? 'S' : 'N',
-        // Force 5 digits before decimal point and 4 digits after
-        ('00000' + (toNmeaDegrees(position.longitude) * 1).toFixed(4)).slice(
-          -10
-        ),
-        position.longitude < 0 ? 'W' : 'E',
+        toNmeaDegreesLatitude(position.latitude),
+        toNmeaDegreesLongitude(position.longitude),
         (sog * 1.94384).toFixed(1),
         radsToDeg(cog).toFixed(1),
         date,

--- a/test/RMC.js
+++ b/test/RMC.js
@@ -26,4 +26,28 @@ describe('RMC', function () {
     app.streambundle.getSelfStream('navigation.courseOverGroundTrue').push('2')
     app.streambundle.getSelfStream('navigation.position').push({longitude: 5, latitude: 6})
   })
+  it('works with large longitude', done => {
+    const streams = {
+        'navigation.speedOverGround': new Bacon.Bus(),
+        'navigation.courseOverGroundTrue': new Bacon.Bus(),
+        'navigation.datetime': new Bacon.Bus(),
+        'navigation.position': new Bacon.Bus(),
+        'navigation.magneticVariation': new Bacon.Bus()
+    }
+    const app = {
+      streambundle: { getSelfStream: path => streams[path] },
+      emit: (event, value) => {
+          assert.equal(value, '$SKRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,,E*43')
+          done()
+      }
+    }
+    const plugin = require('../')(app)
+    const options = {
+      RMC: true
+    }
+    plugin.start(options)
+    app.streambundle.getSelfStream('navigation.speedOverGround').push('1')
+    app.streambundle.getSelfStream('navigation.courseOverGroundTrue').push('2')
+    app.streambundle.getSelfStream('navigation.position').push({longitude: -122.4208, latitude: 37.82673})
+  })
 })

--- a/test/nmea.js
+++ b/test/nmea.js
@@ -1,0 +1,33 @@
+const assert = require('assert')
+const { toNmeaDegreesLatitude, toNmeaDegreesLongitude } = require('../nmea.js')
+
+describe('nmea', function () {
+  describe('toNmeaDegreesLatitude()', function(){
+    it('convert correctly to Degrees and Decimal Minutes in format DDMM.MMMM', function(){
+      assert.equal(toNmeaDegreesLatitude(0),'0000.0000,N')
+      assert.equal(toNmeaDegreesLatitude(0.016668333333333334),'0001.0001,N')
+      assert.equal(toNmeaDegreesLatitude(-1.016668333333333334),'0101.0001,S')
+      assert.equal(toNmeaDegreesLatitude(1.016668333333333334),'0101.0001,N')
+      assert.throws(function(){toNmeaDegreesLatitude(-99.999)}, Error, 'expected Error')
+      assert.throws(function(){toNmeaDegreesLatitude(100)}, Error, 'expected Error')
+      assert.throws(function(){toNmeaDegreesLatitude('23.333')}, Error, 'expected Error')
+      assert.throws(function(){toNmeaDegreesLatitude(undefined)}, Error, 'expected Error')
+      assert.throws(function(){toNmeaDegreesLatitude('hello world')}, Error, 'expected Error')
+    })
+  })
+  describe('toNmeaDegreesLongitude()', function(){
+    it('convert correctly to Degrees and Decimal Minutes in format DDDMM.MMMM', function(){
+      assert.equal(toNmeaDegreesLongitude(0),'00000.0000,E')
+      assert.equal(toNmeaDegreesLongitude(0.016668333333333334),'00001.0001,E')
+      assert.equal(toNmeaDegreesLongitude(-1.016668333333333334),'00101.0001,W')
+      assert.equal(toNmeaDegreesLongitude(1.016668333333333334),'00101.0001,E')
+      assert.equal(toNmeaDegreesLongitude(-99.9999983333333333),'09959.9999,W')
+      assert.equal(toNmeaDegreesLongitude(-122.4208),'12225.2480,W')
+      assert.throws(function(){toNmeaDegreesLongitude(-181)}, Error, 'expected Error')
+      assert.throws(function(){toNmeaDegreesLongitude(197)}, Error, 'expected Error')
+      assert.throws(function(){toNmeaDegreesLongitude('-122')}, Error, 'expected Error')
+      assert.throws(function(){toNmeaDegreesLongitude(undefined)}, Error, 'expected Error')
+      assert.throws(function(){toNmeaDegreesLongitude('hello world')}, Error, 'expected Error')
+    })
+  })
+})


### PR DESCRIPTION
this commit replaced toNmeaDegrees with two separate functions,
toNmeaDegreesLatitude and toNmeaDegreesLongitude. NMEA sentences expect
slightly different formatting since longitude can go up to 180 and thus
requires 3 places in the output.

Includes a test fot the original bug and for various usages and error
states of new functions.

fixes #18