### PR TITLE
chore: Use $II as a talker ID to extend compatibility with other software

### DIFF
--- a/sentences/APB.js
+++ b/sentences/APB.js
@@ -45,7 +45,7 @@ module.exports = function (app) {
     ],
     f: function (xte, originToDest, nextPoint) {
       return nmea.toSentence([
-        '$SKAPB',
+        '$IIAPB',
         'A',
         'A',
         Math.abs(xte),

--- a/sentences/GGA.js
+++ b/sentences/GGA.js
@@ -83,7 +83,7 @@ module.exports = function (app) {
       }
 
       return toSentence([
-        '$SKGGA',
+        '$IIGGA',
         time,
         toNmeaDegreesLatitude(position.latitude),
         toNmeaDegreesLongitude(position.longitude),

--- a/sentences/MWVR.js
+++ b/sentences/MWVR.js
@@ -25,7 +25,7 @@ module.exports = function (app) {
     keys: ['environment.wind.angleApparent', 'environment.wind.speedApparent'],
     f: function (angle, speed) {
       return nmea.toSentence([
-        '$INMWV',
+        '$IIMWV',
         nmea.radsToPositiveDeg(angle).toFixed(2),
         'R',
         speed.toFixed(2),

--- a/sentences/MWVT.js
+++ b/sentences/MWVT.js
@@ -8,7 +8,7 @@ module.exports = function (app) {
 
     f: function (angle, speed) {
       return nmea.toSentence([
-        '$INMWV',
+        '$IIMWV',
         nmea.radsToPositiveDeg(angle).toFixed(2),
         'T',
         speed.toFixed(2),

--- a/sentences/RMC.js
+++ b/sentences/RMC.js
@@ -57,7 +57,7 @@ module.exports = function (app) {
         magneticVariation = magneticVariation * -1;
       }
       return toSentence([
-        '$SKRMC',
+        '$IIRMC',
         time,
         'A',
         toNmeaDegreesLatitude(position.latitude),

--- a/sentences/ROT.js
+++ b/sentences/ROT.js
@@ -7,7 +7,7 @@ module.exports = function (app) {
     keys: ['navigation.rateOfTurn'],
     f: function (rot) {
       var degm = rot * 3437.74677078493
-      return nmea.toSentence(['$SKROT', degm.toFixed(2), 'A'])
+      return nmea.toSentence(['$IIROT', degm.toFixed(2), 'A'])
     }
   }
 }

--- a/sentences/RSA.js
+++ b/sentences/RSA.js
@@ -16,7 +16,7 @@ module.exports = function (app) {
     keys: ['steering.rudderAngle'],
     f: function (rudderAngle) {
       return nmea.toSentence([
-        '$SKRSA',
+        '$IIRSA',
         nmea.radsToDeg(rudderAngle).toFixed(2),
         'A',
         '',

--- a/test/MWV.js
+++ b/test/MWV.js
@@ -5,7 +5,7 @@ const { createAppWithPlugin } = require('./testutil')
 describe('MWV relative', function () {
   it('works with positive angle', done => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$INMWV,180.00,R,2.00,M,A*32')
+      assert.equal(value, '$IIMWV,180.00,R,2.00,M,A*35')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'MWVR')
@@ -17,7 +17,7 @@ describe('MWV relative', function () {
 
   it('works with negative angle', done => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$INMWV,270.00,R,2.00,M,A*3E')
+      assert.equal(value, '$IIMWV,270.00,R,2.00,M,A*39')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'MWVR')
@@ -31,7 +31,7 @@ describe('MWV relative', function () {
 describe('MWV true', function () {
   it('works with positive angle', done => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$INMWV,180.00,T,2.00,M,A*34')
+      assert.equal(value, '$IIMWV,180.00,T,2.00,M,A*33')
       done()
     }
 
@@ -44,7 +44,7 @@ describe('MWV true', function () {
 
   it('works with negative angle', done => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$INMWV,270.00,T,2.00,M,A*38')
+      assert.equal(value, '$IIMWV,270.00,T,2.00,M,A*3F')
       done()
     }
 

--- a/test/RMC.js
+++ b/test/RMC.js
@@ -5,7 +5,7 @@ const {createAppWithPlugin} = require ('./testutil')
 describe('RMC', function () {
   it('works without datetime & magneticVariation', done => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$SKRMC,,A,0600.0000,N,00500.0000,E,1.9,114.6,,,E*5E')
+      assert.equal(value, '$IIRMC,,A,0600.0000,N,00500.0000,E,1.9,114.6,,,E*46')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'RMC')
@@ -18,7 +18,7 @@ describe('RMC', function () {
 
   it('works with large longitude & magnetic variation', done => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$SKRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,180.0,E*64')
+      assert.equal(value, '$IIRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,180.0,E*7C')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'RMC')
@@ -32,7 +32,7 @@ describe('RMC', function () {
 
   it('ignores a too large longitude', done => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$SKRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,,E*43')
+      assert.equal(value, '$IIRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,,E*5B')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'RMC')


### PR DESCRIPTION
To extend compatibility with other software (e.g. SailGrib WR) the talker ID is set to $II.
Very proprietary sentences remain with their original talker ID ($PNKEP, $PSILCD1, $PSILTBS)