### PR TITLE
fix: compatibility with navionics which only accepts $GP for RMC

### DIFF
--- a/sentences/GGA.js
+++ b/sentences/GGA.js
@@ -114,7 +114,7 @@ module.exports = function (app) {
       }
 
       return toSentence([
-        '$IIGGA',
+        '$GPGGA',
         time,
         toNmeaDegreesLatitude(position.latitude),
         toNmeaDegreesLongitude(position.longitude),

--- a/sentences/GLL.js
+++ b/sentences/GLL.js
@@ -6,7 +6,7 @@ $IIGLL,IIII.II,a,yyyyy.yy,a,hhmmss.ss,A,A*hh
  I I I___ I_Longitude, E/W
  I__I_Latidude, N/S
 */
-// NMEA0183 Encoder GLL   $IIGLL,5943.4970,N,2444.1983,E,200001.020,A*16
+// NMEA0183 Encoder GLL   $GPGLL,5943.4970,N,2444.1983,E,200001.020,A*16
 
 const nmea = require('../nmea.js')
 module.exports = function (app) {
@@ -19,7 +19,7 @@ module.exports = function (app) {
       var minutes = ('00' + datetime.getMinutes()).slice(-2)
       var seconds = ('00' + datetime.getSeconds()).slice(-2)
       return nmea.toSentence([
-        '$IIGLL',
+        '$GPGLL',
         nmea.toNmeaDegreesLatitude(position.latitude),
         nmea.toNmeaDegreesLongitude(position.longitude),
         hours + minutes + seconds + '.020',

--- a/sentences/RMC.js
+++ b/sentences/RMC.js
@@ -57,7 +57,7 @@ module.exports = function (app) {
         magneticVariation = magneticVariation * -1;
       }
       return toSentence([
-        '$IIRMC',
+        '$GPRMC',
         time,
         'A',
         toNmeaDegreesLatitude(position.latitude),

--- a/test/GGA.js
+++ b/test/GGA.js
@@ -6,7 +6,7 @@ describe('GGA', function() {
 
   it('works with default values', done => {
      const onEmit = (event, value) => {
-        assert.equal(value ,'$IIGGA,172814,3723.4659,N,12202.2696,W,0,0,0,0,M,0,M,,*52')      
+        assert.equal(value ,'$GPGGA,172814,3723.4659,N,12202.2696,W,0,0,0,0,M,0,M,,*45')
         done()
      }
      const app = createAppWithPlugin(onEmit, 'GGA')
@@ -16,7 +16,7 @@ describe('GGA', function() {
 
   it('works with sample values', done=> {
      const onEmit = (event, value) => {
-        assert.equal(value ,'$IIGGA,172814,3723.4659,N,12202.2696,W,2,6,1.2,18.893,M,-25.669,M,2,0031*53')
+        assert.equal(value ,'$GPGGA,172814,3723.4659,N,12202.2696,W,2,6,1.2,18.893,M,-25.669,M,2,0031*44')
 	done()
      }
      const app = createAppWithPlugin(onEmit, 'GGA')

--- a/test/RMC.js
+++ b/test/RMC.js
@@ -5,7 +5,7 @@ const {createAppWithPlugin} = require ('./testutil')
 describe('RMC', function () {
   it('works without datetime & magneticVariation', done => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$IIRMC,,A,0600.0000,N,00500.0000,E,1.9,114.6,,,E*46')
+      assert.equal(value, '$GPRMC,,A,0600.0000,N,00500.0000,E,1.9,114.6,,,E*51')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'RMC')
@@ -18,7 +18,7 @@ describe('RMC', function () {
 
   it('works with large longitude & magnetic variation', done => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$IIRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,180.0,E*7C')
+      assert.equal(value, '$GPRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,180.0,E*6B')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'RMC')
@@ -32,7 +32,7 @@ describe('RMC', function () {
 
   it('ignores a too large longitude', done => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$IIRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,,E*5B')
+      assert.equal(value, '$GPRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,,E*4C')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'RMC')


### PR DESCRIPTION
This PR sets compatibility with `navionics` which only accepts `$GP` for `RMC, GGA & GLL` as talkerID (#41).
It is not yet possible to modify the talkerID in the signalk-server-node GUI.
A server evolution must be done to be able to update an existing configuration of a plugin without generating an error.