### PR TITLE
Create DPT-surface.js

### DIFF
--- a/sentences/DPT-surface.js
+++ b/sentences/DPT-surface.js
@@ -1,0 +1,26 @@
+/**
+Depth:
+$IIDPT,x.x,x.x,,*hh
+ I I_Sensor offset, >0 = surface transducer distance, >0 = keel transducer distance.
+ I_From Surface To Transduder
+
+ */
+// NMEA0183 Encoder DPT   $IIDPT,69.21,-0.001*60
+const nmea = require('../nmea.js')
+module.exports = function (app) {
+  return {
+    sentence: 'DPT',
+    title: 'DPT - Depth at Surface (using surfaceToTransducer)',
+    keys: [
+      'environment.depth.belowTransducer',
+      'environment.depth.surfaceToTransducer'
+    ],
+    f: function dpt (belowTransducer, surfaceToTransducer) {
+      return nmea.toSentence([
+        '$IIDPT',
+        belowTransducer.toFixed(2),
+        surfaceToTransducer.toFixed(3)
+      ])
+    }
+  }
+}

--- a/sentences/DPT-surface.js
+++ b/sentences/DPT-surface.js
@@ -1,11 +1,12 @@
 /**
-Depth:
-$IIDPT,x.x,x.x,,*hh
- I I_Sensor offset, >0 = surface transducer distance, >0 = keel transducer distance.
- I_From Surface To Transduder
-
+DPT - Depth of Water
+$--DPT,x.x,x.x*hh
+ Fields:
+ - Water depth relative to transducer, meters
+ - Offset from transducer, meters. Positive means distance from transducer to water line, negative means distance from transducer to keel
+ - Checksum
  */
-// NMEA0183 Encoder DPT   $IIDPT,69.21,-0.001*60
+// NMEA0183 Encoder DPT   $IIDPT,9.2,1.1*4B
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {


### PR DESCRIPTION
Using surfaceToTransducer to calculate water depth from surface not bottom of the keel.
    (eg. Airmar DST810 provides surfaceToTransducer.)  
Current DPT sentence uses transducerToKeel which has to be derived (in my case) and measures the depth at the bottom of the keel not the depth of the water. 
https://gpsd.gitlab.io/gpsd/NMEA.html#_dpt_depth_of_water

Personal preference... for extra confusion DPT allows for either.
