### PR TITLE
fix: force transducerToKeel DPT negative 

### DIFF
--- a/sentences/DPT-surface.js
+++ b/sentences/DPT-surface.js
@@ -1,10 +1,13 @@
 /**
 DPT - Depth of Water
-$--DPT,x.x,x.x*hh
- Fields:
- - Water depth relative to transducer, meters
- - Offset from transducer, meters. Positive means distance from transducer to water line, negative means distance from transducer to keel
- - Checksum
+        1   2   3   4
+        |   |   |   |
+ $--DPT,x.x,x.x,x.x*hh<CR><LF>
+Field Number:
+1. Water depth relative to transducer, meters
+2. Offset from transducer, meters positive means distance from transducer to water line negative means distance from transducer to keel
+3. Maximum range scale in use (NMEA 3.0 and above)
+4. Checksum
  */
 // NMEA0183 Encoder DPT   $IIDPT,9.2,1.1*4B
 const nmea = require('../nmea.js')

--- a/sentences/DPT.js
+++ b/sentences/DPT.js
@@ -19,7 +19,7 @@ module.exports = function (app) {
       return nmea.toSentence([
         '$IIDPT',
         belowTransducer.toFixed(2),
-        transducerToKeel.toFixed(3)
+        (-Math.abs(transducerToKeel)).toFixed(3)
       ])
     }
   }

--- a/sentences/DPT.js
+++ b/sentences/DPT.js
@@ -1,9 +1,13 @@
 /**
-Depth:
-$IIDPT,x.x,x.x,,*hh
- I I_Sensor offset, >0 = surface transducer distance, >0 = keel transducer distance.
- I_Bottom transducer distance
-
+DPT - Depth of Water
+        1   2   3   4
+        |   |   |   |
+ $--DPT,x.x,x.x,x.x*hh<CR><LF>
+Field Number:
+1. Water depth relative to transducer, meters
+2. Offset from transducer, meters positive means distance from transducer to water line negative means distance from transducer to keel
+3. Maximum range scale in use (NMEA 3.0 and above)
+4. Checksum
  */
 // NMEA0183 Encoder DPT   $IIDPT,69.21,-0.001*60
 const nmea = require('../nmea.js')


### PR DESCRIPTION
Signal K specification does not specify sign of transducerToKeel,
so one can interpret it to be an absolute value, or like in DPT
sign has a special meaning.

Change the conversion to force it to be negative in DPT.