### PR TITLE
Update HDG.js

### DIFF
--- a/sentences/HDG.js
+++ b/sentences/HDG.js
@@ -10,7 +10,7 @@ module.exports = function (app) {
   return {
     sentence: 'HDG',
     title: 'HDG - Heading magnetic:.',
-    keys: ['navigation.headingMagnetic', 'navigation.magneticVariation' ],
+    keys: ['navigation.headingMagnetic', , , 'navigation.magneticVariation' ],
     defaults: [undefined, ''],
     f: function hdg (headingMagnetic, magneticVariation) {
       var magneticVariationDir = ''


### PR DESCRIPTION
Fixing incorrect HDG keys.  Original was placing variation in the deviation field resulting in incorrect heading readings in certain software like TimeZero.  OpenCPN for some reason works with either formatting, but TimeZero will display incorrect true and magnetic heading, effectively applying the deviation to the magnetic heading and then again the same variation value to calculate true heading.