### PR TITLE
WIP: Restructured configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const {
 } = require('./nmea')
 const path = require('path')
 const fs = require('fs')
+const { type } = require('os')
 
 module.exports = function (app) {
   var plugin = {
@@ -85,20 +86,27 @@ module.exports = function (app) {
 }
 
 function buildSchemaFromSentences (plugin) {
-  Object.keys(plugin.sentences).forEach(key => {
-    var sentence = plugin.sentences[key]
-    const throttlePropname = getThrottlePropname(key)
-    plugin.schema.properties[key] = {
-      title: sentence['title'],
-      type: 'boolean',
-      default: false
+
+  plugin.schema.properties['Active Conversions'] = {
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        "Sentence": {
+          "type": "string",
+          "enum": Object.keys(plugin.sentences).map(key => `${key}: ${plugin.sentences[key].title}`)
+        },
+        "Minimum interval (milliseconds)": {
+          "type": "number",
+          "description": "Minimum interval between sentences"
+        },
+        "Event": {
+          "type": "string",
+          "description": "Event name to emit the sentence"
+        }
+      }
     }
-    plugin.schema.properties[throttlePropname] = {
-      title: `${key} throttle ms`,
-      type: 'number',
-      default: 0
-    }
-  })
+  }
 }
 
 function loadSentences (app, plugin) {


### PR DESCRIPTION
The current way to configure the plugin is pretty awful: a single, really long list of sentences. Would something like this be an improvement? It allows adding more properties for each conversion (here a custom event name) and the list is just the active conversions.

<img width="810" alt="image" src="https://github.com/user-attachments/assets/8c931708-5cb9-4482-b55f-25ae612dffd2" />
