### PR TITLE
Fix/wrong time in gll

### DIFF
--- a/nmea.js
+++ b/nmea.js
@@ -142,6 +142,43 @@ function radsToPositiveDeg(r) {
   return radsToDeg(toPositiveRadians(r))
 }
 
+function formatDatetime(datetime8601) {
+  if (datetime8601 && typeof datetime8601 === 'string' && datetime8601.length > 0) {
+    const datetime = new Date(datetime8601);
+
+    const hours = ('00' + datetime.getUTCHours()).slice(-2);
+    const minutes = ('00' + datetime.getUTCMinutes()).slice(-2);
+    const seconds = ('00' + datetime.getUTCSeconds()).slice(-2);
+
+    const day = ('00' + datetime.getUTCDate()).slice(-2);
+    const month = ('00' + (datetime.getUTCMonth() + 1)).slice(-2); // months from 1-12
+    const year = ('00' + datetime.getUTCFullYear()).slice(-2);
+    return {
+      hours: hours,
+      minutes: minutes,
+      seconds: seconds,
+      // NMEA0183 time format is hhmmss.ss
+      time: hours + minutes + seconds,
+      day: day,
+      month: month,
+      year: year,
+      // NMEA0183 date format is ddmmyy
+      date: day + month + year
+    };
+  } else {
+    return {
+      hours: '',
+      minutes: '',
+      seconds: '',
+      time: '',
+      day: '',
+      month: '',
+      year: '',
+      date: ''
+    };
+  }
+}
+
 module.exports = {
   toSentence: toSentence,
   radsToDeg: radsToDeg,
@@ -151,5 +188,6 @@ module.exports = {
   toNmeaDegreesLongitude: toNmeaDegreesLongitude,
   fixAngle: fixAngle,
   radsToPositiveDeg,
-  mToNm
+  mToNm,
+  formatDatetime: formatDatetime
 }

--- a/nmea.js
+++ b/nmea.js
@@ -146,41 +146,53 @@ function radsToPositiveDeg(r) {
 // Input:  '2025-04-27T14:34:56.789+02:00'
 // Output: { hours: '12', minutes: '34', seconds: '56', centiseconds: '78',
 //           time: '123456.78', day: '27', month: '04', year: '2025', date: '270425' }
-function formatDatetime (datetime8601) {
-  if (datetime8601 && typeof datetime8601 === 'string' && datetime8601.length > 0) {
-    var datetime = new Date(datetime8601)
+//
+// The input must include a timezone designator (e.g. 'Z' or '+02:00'). A naive
+// ISO string like '2025-04-27T14:34:56' is interpreted as LOCAL time by the
+// Date constructor, which is exactly the class of bug this function exists to
+// prevent. Non-string, empty, or unparseable input returns empty fields.
+function formatDatetime(datetime8601) {
+  const empty = {
+    hours: '',
+    minutes: '',
+    seconds: '',
+    centiseconds: '',
+    time: '',
+    day: '',
+    month: '',
+    year: '',
+    date: ''
+  }
 
-    var hours = ('00' + datetime.getUTCHours()).slice(-2)
-    var minutes = ('00' + datetime.getUTCMinutes()).slice(-2)
-    var seconds = ('00' + datetime.getUTCSeconds()).slice(-2)
-    var centiseconds = ('00' + Math.floor(datetime.getUTCMilliseconds() / 10)).slice(-2)
+  if (typeof datetime8601 !== 'string' || datetime8601.length === 0) {
+    return empty
+  }
 
-    var day = ('00' + datetime.getUTCDate()).slice(-2)
-    var month = ('00' + (datetime.getUTCMonth() + 1)).slice(-2)
-    var year = '' + datetime.getUTCFullYear()
-    return {
-      hours: hours,
-      minutes: minutes,
-      seconds: seconds,
-      centiseconds: centiseconds,
-      time: hours + minutes + seconds + '.' + centiseconds,
-      day: day,
-      month: month,
-      year: year,
-      date: day + month + ('00' + year).slice(-2)
-    }
-  } else {
-    return {
-      hours: '',
-      minutes: '',
-      seconds: '',
-      centiseconds: '',
-      time: '',
-      day: '',
-      month: '',
-      year: '',
-      date: ''
-    }
+  const datetime = new Date(datetime8601)
+  if (isNaN(datetime.getTime())) {
+    return empty
+  }
+
+  const hours = ('00' + datetime.getUTCHours()).slice(-2)
+  const minutes = ('00' + datetime.getUTCMinutes()).slice(-2)
+  const seconds = ('00' + datetime.getUTCSeconds()).slice(-2)
+  const centiseconds = (
+    '00' + Math.floor(datetime.getUTCMilliseconds() / 10)
+  ).slice(-2)
+
+  const day = ('00' + datetime.getUTCDate()).slice(-2)
+  const month = ('00' + (datetime.getUTCMonth() + 1)).slice(-2)
+  const year = '' + datetime.getUTCFullYear()
+  return {
+    hours,
+    minutes,
+    seconds,
+    centiseconds,
+    time: hours + minutes + seconds + '.' + centiseconds,
+    day,
+    month,
+    year,
+    date: day + month + ('00' + year).slice(-2)
   }
 }
 

--- a/nmea.js
+++ b/nmea.js
@@ -142,40 +142,45 @@ function radsToPositiveDeg(r) {
   return radsToDeg(toPositiveRadians(r))
 }
 
-function formatDatetime(datetime8601) {
+// Parses an ISO 8601 datetime string into NMEA0183 time/date components (UTC).
+// Input:  '2025-04-27T14:34:56.789+02:00'
+// Output: { hours: '12', minutes: '34', seconds: '56', centiseconds: '78',
+//           time: '123456.78', day: '27', month: '04', year: '2025', date: '270425' }
+function formatDatetime (datetime8601) {
   if (datetime8601 && typeof datetime8601 === 'string' && datetime8601.length > 0) {
-    const datetime = new Date(datetime8601);
+    var datetime = new Date(datetime8601)
 
-    const hours = ('00' + datetime.getUTCHours()).slice(-2);
-    const minutes = ('00' + datetime.getUTCMinutes()).slice(-2);
-    const seconds = ('00' + datetime.getUTCSeconds()).slice(-2);
+    var hours = ('00' + datetime.getUTCHours()).slice(-2)
+    var minutes = ('00' + datetime.getUTCMinutes()).slice(-2)
+    var seconds = ('00' + datetime.getUTCSeconds()).slice(-2)
+    var centiseconds = ('00' + Math.floor(datetime.getUTCMilliseconds() / 10)).slice(-2)
 
-    const day = ('00' + datetime.getUTCDate()).slice(-2);
-    const month = ('00' + (datetime.getUTCMonth() + 1)).slice(-2); // months from 1-12
-    const year = ('00' + datetime.getUTCFullYear()).slice(-2);
+    var day = ('00' + datetime.getUTCDate()).slice(-2)
+    var month = ('00' + (datetime.getUTCMonth() + 1)).slice(-2)
+    var year = '' + datetime.getUTCFullYear()
     return {
       hours: hours,
       minutes: minutes,
       seconds: seconds,
-      // NMEA0183 time format is hhmmss.ss
-      time: hours + minutes + seconds,
+      centiseconds: centiseconds,
+      time: hours + minutes + seconds + '.' + centiseconds,
       day: day,
       month: month,
       year: year,
-      // NMEA0183 date format is ddmmyy
-      date: day + month + year
-    };
+      date: day + month + ('00' + year).slice(-2)
+    }
   } else {
     return {
       hours: '',
       minutes: '',
       seconds: '',
+      centiseconds: '',
       time: '',
       day: '',
       month: '',
       year: '',
       date: ''
-    };
+    }
   }
 }
 

--- a/sentences/GGA.js
+++ b/sentences/GGA.js
@@ -2,7 +2,7 @@
   GGA - Time, position, and fix related data
   This is one of the sentences commonly emitted by GPS units.
   0      1        2             3 4              5 6 7 8   9     10 11     12 13  14
-  |      |        |             | |              | | | |   |      | |       | |   |     
+  |      |        |             | |              | | | |   |      | |       | |   |
   $GPGGA,172814.0,3723.46587704,N,12202.26957864,W,2,6,1.2,18.893,M,-25.669,M,2.0,0031*hh<CR><LF>
 
   Field Number:
@@ -11,7 +11,7 @@
   2	Latitude
   3	Direction of latitude: N (north) or S (south)
   4	Longitude
-  5	Direction of longitude: E (east) or W (west) 
+  5	Direction of longitude: E (east) or W (west)
   6	GPS Quality indicator: 0 = Fix not valid; 1 = GPS fix; 2 = Differential GPS fix, OmniSTAR VBS; 4 = Real-Time Kinematic, fixed integers; 5 = Real-Time Kinematic, float integers, OmniSTAR XP/HP or Location RTK
   7	Number of SVs in use, range from 00 through to 24+
   8	HDOP
@@ -26,7 +26,8 @@
 const {
   toSentence,
   toNmeaDegreesLatitude,
-  toNmeaDegreesLongitude
+  toNmeaDegreesLongitude,
+  formatDatetime
 } = require('../nmea.js')
 
 module.exports = function (app) {
@@ -66,7 +67,6 @@ module.exports = function (app) {
       gnssDifferentialAge,
       gnssDifferentialReference
     ) {
-      let time = ''
       let ignssMethodQuality = 0
 
       if (
@@ -76,13 +76,7 @@ module.exports = function (app) {
         datetime8601 = new Date().toISOString()
       }
 
-      if (datetime8601.length > 0) {
-        let datetime = new Date(datetime8601)
-        let hours = ('00' + datetime.getUTCHours()).slice(-2)
-        let minutes = ('00' + datetime.getUTCMinutes()).slice(-2)
-        let seconds = ('00' + datetime.getUTCSeconds()).slice(-2)
-        time = hours + minutes + seconds
-      }
+      const datetime = formatDatetime(datetime8601)
 
       if (!position) {
         console.error(`[signalk-to-nmea0183] GGA: no position, not converting`)
@@ -129,7 +123,7 @@ module.exports = function (app) {
 
       return toSentence([
         '$GPGGA',
-        time,
+        datetime.time,
         toNmeaDegreesLatitude(position.latitude),
         toNmeaDegreesLongitude(position.longitude),
         ignssMethodQuality,

--- a/sentences/GLL.js
+++ b/sentences/GLL.js
@@ -1,30 +1,29 @@
 /*
 Geographical position, latitude and longitude:
-$IIGLL,IIII.II,a,yyyyy.yy,a,hhmmss.ss,A,A*hh
- I I I I I I_Statut, A= valid data, V= non valid data
- I I I I I_UTC time
- I I I___ I_Longitude, E/W
- I__I_Latidude, N/S
+$--GLL,llll.ll,a,yyyyy.yy,a,hhmmss.ss,A*hh
+       |       | |        | |          |_Status (A=valid, V=invalid)
+       |       | |        | |_UTC time
+       |       | |________|_Longitude, E/W
+       |_______|_Latitude, N/S
+
+Example: $GPGLL,5943.4970,N,02444.1983,E,200001.00,A*03
 */
-// NMEA0183 Encoder GLL   $GPGLL,5943.4970,N,2444.1983,E,200001.020,A*16
 
 const nmea = require('../nmea.js')
+const { formatDatetime } = nmea
 module.exports = function (app) {
   return {
     sentence: 'GLL',
     title: 'GLL - Geographical position, latitude and longitude',
     keys: ['navigation.datetime', 'navigation.position'],
     f: function gll(datetime8601, position) {
-      var datetime = new Date(datetime8601)
-      var hours = ('00' + datetime.getHours()).slice(-2)
-      var minutes = ('00' + datetime.getMinutes()).slice(-2)
-      var seconds = ('00' + datetime.getSeconds()).slice(-2)
+      const datetime = formatDatetime(datetime8601)
       if (position !== null) {
         return nmea.toSentence([
           '$GPGLL',
           nmea.toNmeaDegreesLatitude(position.latitude),
           nmea.toNmeaDegreesLongitude(position.longitude),
-          hours + minutes + seconds + '.020',
+          datetime.time,
           'A'
         ])
       }

--- a/sentences/RMC.js
+++ b/sentences/RMC.js
@@ -21,14 +21,13 @@
       12 FAA mode indicator (NMEA 2.3 and later)
       13 Checksum
     */
-// This needs to run faster that others.
-
-// NMEA0183 Encoder RMC   $INRMC,200152.020,A,5943.2980,N,2444.1043,E,6.71,194.30,0000,8.1,E*40
+// Example: $GPRMC,200152.00,A,5943.2980,N,02444.1043,E,6.7,194.3,051215,8.1,E*5B
 const {
   toSentence,
   toNmeaDegreesLatitude,
   toNmeaDegreesLongitude,
-  radsToDeg
+  radsToDeg,
+  formatDatetime
 } = require('../nmea.js')
 module.exports = function (app) {
   return {
@@ -43,34 +42,21 @@ module.exports = function (app) {
     ],
     defaults: ['', undefined, undefined, undefined, ''],
     f: function (datetime8601, sog, cog, position, magneticVariation) {
-      let time = ''
-      let date = ''
-      if (datetime8601.length > 0) {
-        let datetime = new Date(datetime8601)
-        let hours = ('00' + datetime.getUTCHours()).slice(-2)
-        let minutes = ('00' + datetime.getUTCMinutes()).slice(-2)
-        let seconds = ('00' + datetime.getUTCSeconds()).slice(-2)
-
-        let day = ('00' + datetime.getUTCDate()).slice(-2)
-        let month = ('00' + (datetime.getUTCMonth() + 1)).slice(-2) // months from 1-12
-        let year = ('00' + datetime.getUTCFullYear()).slice(-2)
-        time = hours + minutes + seconds
-        date = day + month + year
-      }
-      var magneticVariationDir = 'E'
+      const datetime = formatDatetime(datetime8601)
+      let magneticVariationDir = 'E'
       if (magneticVariation < 0) {
         magneticVariationDir = 'W'
         magneticVariation = magneticVariation * -1
       }
       return toSentence([
         '$GPRMC',
-        time,
+        datetime.time,
         'A',
         toNmeaDegreesLatitude(position.latitude),
         toNmeaDegreesLongitude(position.longitude),
         (sog * 1.94384).toFixed(1),
         radsToDeg(cog).toFixed(1),
-        date,
+        datetime.date,
         typeof magneticVariation === 'number'
           ? radsToDeg(magneticVariation).toFixed(1)
           : magneticVariation,

--- a/sentences/ZDA.js
+++ b/sentences/ZDA.js
@@ -13,18 +13,13 @@ module.exports = function (app) {
     title: 'ZDA - UTC time and date',
     keys: ['navigation.datetime'],
     f: function (datetime8601) {
-      var datetime = new Date(datetime8601)
-      var hours = ('00' + datetime.getUTCHours()).slice(-2)
-      var minutes = ('00' + datetime.getUTCMinutes()).slice(-2)
-      var seconds = ('00' + datetime.getUTCSeconds()).slice(-2)
-      var day = ('00' + datetime.getUTCDate()).slice(-2)
-      var month = ('00' + (datetime.getUTCMonth() + 1)).slice(-2)
+      const datetime = formatDatetime(datetime8601);
       return nmea.toSentence([
         '$IIZDA',
-        hours + minutes + seconds + '.020',
-        day,
-        month,
-        datetime.getUTCFullYear(),
+        datetime.time + '.020',
+        datetime.day,
+        datetime.month,
+        datetime.year,
         '',
         ''
       ])

--- a/sentences/ZDA.js
+++ b/sentences/ZDA.js
@@ -1,22 +1,26 @@
 /*
 UTC time and date:
-$IIZDA,hhmmss.ss,xx,xx,xxxx,,*hh
- I I I I_Year
- I I I_Month
- I I_Day
- I_Time
- */
-// NMEA0183 Encoder ZDA   $IIZDA,200006.020,15,08,2014,,*4C
+$--ZDA,hhmmss.ss,dd,mm,yyyy,zz,zz*hh
+       |         |  |  |    |  |_Local zone minutes (00)
+       |         |  |  |    |_Local zone hours (00)
+       |         |  |  |_Year (4-digit)
+       |         |  |_Month (01-12)
+       |         |_Day (01-31)
+       |_UTC time
+
+Example: $IIZDA,200006.00,15,08,2014,,*7E
+*/
 const nmea = require('../nmea.js')
+const { formatDatetime } = require('../nmea.js')
 module.exports = function (app) {
   return {
     title: 'ZDA - UTC time and date',
     keys: ['navigation.datetime'],
     f: function (datetime8601) {
-      const datetime = formatDatetime(datetime8601);
+      var datetime = formatDatetime(datetime8601)
       return nmea.toSentence([
         '$IIZDA',
-        datetime.time + '.020',
+        datetime.time,
         datetime.day,
         datetime.month,
         datetime.year,

--- a/sentences/ZDA.js
+++ b/sentences/ZDA.js
@@ -1,8 +1,8 @@
 /*
 UTC time and date:
 $--ZDA,hhmmss.ss,dd,mm,yyyy,zz,zz*hh
-       |         |  |  |    |  |_Local zone minutes (00)
-       |         |  |  |    |_Local zone hours (00)
+       |         |  |  |    |  |_Local zone minutes (empty when reporting UTC)
+       |         |  |  |    |_Local zone hours (empty when reporting UTC)
        |         |  |  |_Year (4-digit)
        |         |  |_Month (01-12)
        |         |_Day (01-31)
@@ -11,13 +11,13 @@ $--ZDA,hhmmss.ss,dd,mm,yyyy,zz,zz*hh
 Example: $IIZDA,200006.00,15,08,2014,,*7E
 */
 const nmea = require('../nmea.js')
-const { formatDatetime } = require('../nmea.js')
+const { formatDatetime } = nmea
 module.exports = function (app) {
   return {
     title: 'ZDA - UTC time and date',
     keys: ['navigation.datetime'],
     f: function (datetime8601) {
-      var datetime = formatDatetime(datetime8601)
+      const datetime = formatDatetime(datetime8601)
       return nmea.toSentence([
         '$IIZDA',
         datetime.time,

--- a/test/GGA.js
+++ b/test/GGA.js
@@ -7,7 +7,7 @@ describe('GGA', function () {
     const onEmit = (event, value) => {
       assert.equal(
         value,
-        '$GPGGA,172814,3723.4659,N,12202.2696,W,0,0,0.0,0.0,M,0.0,M,,*5B'
+        '$GPGGA,172814.00,3723.4659,N,12202.2696,W,0,0,0.0,0.0,M,0.0,M,,*75'
       )
       done()
     }
@@ -24,7 +24,7 @@ describe('GGA', function () {
     const onEmit = (event, value) => {
       assert.equal(
         value,
-        '$GPGGA,172814,3723.4659,N,12202.2696,W,2,6,1.2,18.9,M,-25.7,M,2,0031*41'
+        '$GPGGA,172814.00,3723.4659,N,12202.2696,W,2,6,1.2,18.9,M,-25.7,M,2,0031*6F'
       )
       done()
     }

--- a/test/GLL.js
+++ b/test/GLL.js
@@ -2,18 +2,18 @@ const assert = require('assert')
 
 const { createAppWithPlugin } = require('./testutil')
 
-// Multi-input sentence with NO defaults. Exercises combineStreamsWith with
-// multiple non-defaulted streams — both inputs are plain Buses, the helper's
-// chained .combine path is what produces the Property the downstream
-// .changes() needs.
 describe('GLL', function () {
+  // Multi-input sentence with NO defaults. Exercises combineStreamsWith with
+  // multiple non-defaulted streams — both inputs are plain Buses, the helper's
+  // chained .combine path is what produces the Property the downstream
+  // .changes() needs.
   it('emits position once both datetime and position have been pushed', (done) => {
     const onEmit = (event, value) => {
-      // Format: $GPGLL,lat,N|S,lon,E|W,hhmmss.020,A*<checksum>
+      // Format: $GPGLL,lat,N|S,lon,E|W,hhmmss.ss,A*<checksum>
       // Position 47.5/8.5 → 4730.0000,N,00830.0000,E
       assert.match(
         value,
-        /^\$GPGLL,4730\.0000,N,00830\.0000,E,\d{6}\.020,A\*[0-9A-F]{2}$/
+        /^\$GPGLL,4730\.0000,N,00830\.0000,E,\d{6}\.\d{2},A\*[0-9A-F]{2}$/
       )
       done()
     }
@@ -24,5 +24,65 @@ describe('GLL', function () {
     app.streambundle
       .getSelfStream('navigation.position')
       .push({ longitude: 8.5, latitude: 47.5 })
+  })
+
+  it('produces correct sentence with UTC datetime', (done) => {
+    const onEmit = (event, value) => {
+      assert.equal(value, '$GPGLL,5943.4970,N,02444.1983,E,200001.00,A*03')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'GLL')
+    app.streambundle
+      .getSelfStream('navigation.datetime')
+      .push('2015-12-05T20:00:01Z')
+    app.streambundle
+      .getSelfStream('navigation.position')
+      .push({ longitude: 24.736638, latitude: 59.72495 })
+  })
+
+  it('converts timezone-offset input to UTC', (done) => {
+    // 14:34:56+02:00 = 12:34:56 UTC
+    const onEmit = (event, value) => {
+      assert.equal(value, '$GPGLL,5943.4970,N,02444.1983,E,123456.00,A*07')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'GLL')
+    app.streambundle
+      .getSelfStream('navigation.datetime')
+      .push('2025-04-27T14:34:56+02:00')
+    app.streambundle
+      .getSelfStream('navigation.position')
+      .push({ longitude: 24.736638, latitude: 59.72495 })
+  })
+
+  it('includes fractional seconds from input', (done) => {
+    // 789ms = 78 centiseconds
+    const onEmit = (event, value) => {
+      assert.equal(value, '$GPGLL,5943.4970,N,02444.1983,E,123456.78,A*08')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'GLL')
+    app.streambundle
+      .getSelfStream('navigation.datetime')
+      .push('2025-04-27T12:34:56.789Z')
+    app.streambundle
+      .getSelfStream('navigation.position')
+      .push({ longitude: 24.736638, latitude: 59.72495 })
+  })
+
+  it('does not emit when position is null', (done) => {
+    let emitted = false
+    const onEmit = () => {
+      emitted = true
+    }
+    const app = createAppWithPlugin(onEmit, 'GLL')
+    app.streambundle
+      .getSelfStream('navigation.datetime')
+      .push('2025-04-27T12:34:56Z')
+    app.streambundle.getSelfStream('navigation.position').push(null)
+    setTimeout(() => {
+      assert.equal(emitted, false)
+      done()
+    }, 50)
   })
 })

--- a/test/RMC.js
+++ b/test/RMC.js
@@ -51,4 +51,73 @@ describe('RMC', function () {
         .push({ longitude: -122.4208, latitude: 37.82673 })
     }, 50)
   })
+
+  it('populates UTC time and ddmmyy date from a valid datetime', (done) => {
+    // Verifies the formatDatetime() output is threaded through RMC: time field
+    // uses the hhmmss.ss format (with centiseconds) and date field is ddmmyy.
+    const onEmit = (event, value) => {
+      assert.equal(
+        value,
+        '$GPRMC,200152.00,A,5943.2980,N,02444.2043,E,13.0,194.3,051215,,E*46'
+      )
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMC')
+    app.streambundle
+      .getSelfStream('navigation.datetime')
+      .push('2015-12-05T20:01:52Z')
+    app.streambundle.getSelfStream('navigation.speedOverGround').push(6.71)
+    app.streambundle
+      .getSelfStream('navigation.courseOverGroundTrue')
+      .push(3.391964)
+    app.streambundle
+      .getSelfStream('navigation.position')
+      .push({ longitude: 24.736738, latitude: 59.721633 })
+  })
+
+  it('converts timezone-offset datetime to UTC', (done) => {
+    // 14:34:56+02:00 on 2025-04-27 = 12:34:56 UTC, same date.
+    const onEmit = (event, value) => {
+      assert.ok(
+        value.startsWith('$GPRMC,123456.00,A,'),
+        'expected UTC time 123456.00 in RMC sentence, got ' + value
+      )
+      assert.ok(
+        value.includes(',270425,'),
+        'expected date 270425 in RMC sentence, got ' + value
+      )
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMC')
+    app.streambundle
+      .getSelfStream('navigation.datetime')
+      .push('2025-04-27T14:34:56+02:00')
+    app.streambundle.getSelfStream('navigation.speedOverGround').push(1)
+    app.streambundle.getSelfStream('navigation.courseOverGroundTrue').push(2)
+    app.streambundle
+      .getSelfStream('navigation.position')
+      .push({ longitude: 5, latitude: 6 })
+  })
+
+  it('reports a negative magnetic variation as W', (done) => {
+    // Negative radians must flip the hemisphere indicator to W and emit the
+    // absolute value of the variation. Covers the magneticVariation < 0 branch
+    // in RMC.js (the only remaining uncovered branch in that file).
+    const onEmit = (event, value) => {
+      assert.equal(
+        value,
+        '$GPRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,180.0,W*79'
+      )
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMC')
+    app.streambundle.getSelfStream('navigation.speedOverGround').push('1')
+    app.streambundle.getSelfStream('navigation.courseOverGroundTrue').push('2')
+    app.streambundle
+      .getSelfStream('navigation.magneticVariation')
+      .push(-Math.PI)
+    app.streambundle
+      .getSelfStream('navigation.position')
+      .push({ longitude: -122.4208, latitude: 37.82673 })
+  })
 })

--- a/test/ZDA.js
+++ b/test/ZDA.js
@@ -1,43 +1,54 @@
 const assert = require('assert')
 
-const {createAppWithPlugin} = require ('./testutil')
+const { createAppWithPlugin } = require('./testutil')
 
 describe('ZDA', function () {
-  it('produces correct sentence with UTC datetime', done => {
+  it('produces correct sentence with UTC datetime', (done) => {
     const onEmit = (event, value) => {
       assert.equal(value, '$IIZDA,200006.00,15,08,2014,,*7E')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'ZDA')
-    app.streambundle.getSelfStream('navigation.datetime').push('2014-08-15T20:00:06Z')
+    app.streambundle
+      .getSelfStream('navigation.datetime')
+      .push('2014-08-15T20:00:06Z')
   })
 
-  it('uses UTC time for timezone-offset input', done => {
+  it('uses UTC time for timezone-offset input', (done) => {
     const onEmit = (event, value) => {
       // 14:34:56+02:00 = 12:34:56 UTC, date stays 27 April 2025
       assert.equal(value, '$IIZDA,123456.00,27,04,2025,,*72')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'ZDA')
-    app.streambundle.getSelfStream('navigation.datetime').push('2025-04-27T14:34:56+02:00')
+    app.streambundle
+      .getSelfStream('navigation.datetime')
+      .push('2025-04-27T14:34:56+02:00')
   })
 
-  it('handles day-crossing timezone offset', done => {
+  it('handles day-crossing timezone offset', (done) => {
     const onEmit = (event, value) => {
       assert.equal(value, '$IIZDA,200000.00,27,04,2025,,*77')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'ZDA')
-    app.streambundle.getSelfStream('navigation.datetime').push('2025-04-28T01:00:00+05:00')
+    app.streambundle
+      .getSelfStream('navigation.datetime')
+      .push('2025-04-28T01:00:00+05:00')
   })
 
-  it('uses full 4-digit year', done => {
+  it('uses full 4-digit year', (done) => {
     const onEmit = (event, value) => {
       // Year must be 4 digits per ZDA spec (xxxx)
-      assert.ok(value.includes(',2025,'), 'expected 4-digit year in ZDA sentence')
+      assert.ok(
+        value.includes(',2025,'),
+        'expected 4-digit year in ZDA sentence'
+      )
       done()
     }
     const app = createAppWithPlugin(onEmit, 'ZDA')
-    app.streambundle.getSelfStream('navigation.datetime').push('2025-04-27T12:34:56Z')
+    app.streambundle
+      .getSelfStream('navigation.datetime')
+      .push('2025-04-27T12:34:56Z')
   })
 })

--- a/test/ZDA.js
+++ b/test/ZDA.js
@@ -1,0 +1,43 @@
+const assert = require('assert')
+
+const {createAppWithPlugin} = require ('./testutil')
+
+describe('ZDA', function () {
+  it('produces correct sentence with UTC datetime', done => {
+    const onEmit = (event, value) => {
+      assert.equal(value, '$IIZDA,200006.00,15,08,2014,,*7E')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'ZDA')
+    app.streambundle.getSelfStream('navigation.datetime').push('2014-08-15T20:00:06Z')
+  })
+
+  it('uses UTC time for timezone-offset input', done => {
+    const onEmit = (event, value) => {
+      // 14:34:56+02:00 = 12:34:56 UTC, date stays 27 April 2025
+      assert.equal(value, '$IIZDA,123456.00,27,04,2025,,*72')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'ZDA')
+    app.streambundle.getSelfStream('navigation.datetime').push('2025-04-27T14:34:56+02:00')
+  })
+
+  it('handles day-crossing timezone offset', done => {
+    const onEmit = (event, value) => {
+      assert.equal(value, '$IIZDA,200000.00,27,04,2025,,*77')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'ZDA')
+    app.streambundle.getSelfStream('navigation.datetime').push('2025-04-28T01:00:00+05:00')
+  })
+
+  it('uses full 4-digit year', done => {
+    const onEmit = (event, value) => {
+      // Year must be 4 digits per ZDA spec (xxxx)
+      assert.ok(value.includes(',2025,'), 'expected 4-digit year in ZDA sentence')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'ZDA')
+    app.streambundle.getSelfStream('navigation.datetime').push('2025-04-27T12:34:56Z')
+  })
+})

--- a/test/nmea.js
+++ b/test/nmea.js
@@ -1,5 +1,9 @@
 const assert = require('assert')
-const { formatDatetime, toNmeaDegreesLatitude, toNmeaDegreesLongitude } = require('../nmea.js')
+const {
+  formatDatetime,
+  toNmeaDegreesLatitude,
+  toNmeaDegreesLongitude
+} = require('../nmea.js')
 
 describe('nmea', function () {
   describe('toNmeaDegreesLatitude()', function () {
@@ -197,7 +201,7 @@ describe('nmea', function () {
     })
 
     it('returns empty fields for invalid input', function () {
-      var empty = {
+      const empty = {
         date: '',
         day: '',
         hours: '',
@@ -212,6 +216,25 @@ describe('nmea', function () {
       assert.deepEqual(formatDatetime(null), empty)
       assert.deepEqual(formatDatetime(undefined), empty)
       assert.deepEqual(formatDatetime(''), empty)
+    })
+
+    it('returns empty fields for unparseable date strings', function () {
+      // Non-empty strings that Date() cannot parse must not leak NaN into the
+      // output sentence. Covers typos, garbage, and out-of-range components.
+      const empty = {
+        date: '',
+        day: '',
+        hours: '',
+        minutes: '',
+        month: '',
+        seconds: '',
+        centiseconds: '',
+        time: '',
+        year: ''
+      }
+      assert.deepEqual(formatDatetime('not-a-date'), empty)
+      assert.deepEqual(formatDatetime('hello world'), empty)
+      assert.deepEqual(formatDatetime('2025-13-45T99:99:99Z'), empty)
     })
   })
 })

--- a/test/nmea.js
+++ b/test/nmea.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const { formatDatetime, toNmeaDegreesLatitude, toNmeaDegreesLongitude } = require('../nmea.js');
+const assert = require('assert')
+const { formatDatetime, toNmeaDegreesLatitude, toNmeaDegreesLongitude } = require('../nmea.js')
 
 describe('nmea', function () {
   describe('toNmeaDegreesLatitude()', function () {
@@ -93,8 +93,6 @@ describe('nmea', function () {
       )
     })
   })
-})
-
   describe('formatDatetime()', function () {
     it('formats ISO datetime strings to NMEA0183 format', function () {
       assert.deepEqual(formatDatetime('2025-04-27T12:34:56Z'), {
@@ -104,10 +102,11 @@ describe('nmea', function () {
         minutes: '34',
         month: '04',
         seconds: '56',
-        time: '123456',
-        year: '25'
-      });
-    });
+        centiseconds: '00',
+        time: '123456.00',
+        year: '2025'
+      })
+    })
 
     it('handles timezones with +02:00 offset', function () {
       assert.deepEqual(formatDatetime('2025-04-27T14:34:56+02:00'), {
@@ -117,10 +116,11 @@ describe('nmea', function () {
         minutes: '34',
         month: '04',
         seconds: '56',
-        time: '123456',
-        year: '25'
-      });
-    });
+        centiseconds: '00',
+        time: '123456.00',
+        year: '2025'
+      })
+    })
 
     it('handles timezones with -05:00 offset', function () {
       assert.deepEqual(formatDatetime('2025-04-27T07:34:56-05:00'), {
@@ -130,10 +130,11 @@ describe('nmea', function () {
         minutes: '34',
         month: '04',
         seconds: '56',
-        time: '123456',
-        year: '25'
-      });
-    });
+        centiseconds: '00',
+        time: '123456.00',
+        year: '2025'
+      })
+    })
 
     it('handles timezones with +00:00 offset (UTC)', function () {
       assert.deepEqual(formatDatetime('2025-04-27T12:34:56+00:00'), {
@@ -143,42 +144,74 @@ describe('nmea', function () {
         minutes: '34',
         month: '04',
         seconds: '56',
-        time: '123456',
-        year: '25'
-      });
-    });
+        centiseconds: '00',
+        time: '123456.00',
+        year: '2025'
+      })
+    })
 
-    it('returns empty', function () {
-      assert.deepEqual(formatDatetime(1), {
+    it('preserves fractional seconds as centiseconds', function () {
+      // 789ms = 78 centiseconds (truncated, not rounded)
+      assert.deepEqual(formatDatetime('2025-04-27T12:34:56.789Z'), {
+        date: '270425',
+        day: '27',
+        hours: '12',
+        minutes: '34',
+        month: '04',
+        seconds: '56',
+        centiseconds: '78',
+        time: '123456.78',
+        year: '2025'
+      })
+    })
+
+    it('pads midnight correctly', function () {
+      assert.deepEqual(formatDatetime('2025-01-01T00:00:00Z'), {
+        date: '010125',
+        day: '01',
+        hours: '00',
+        minutes: '00',
+        month: '01',
+        seconds: '00',
+        centiseconds: '00',
+        time: '000000.00',
+        year: '2025'
+      })
+    })
+
+    it('handles day-crossing timezone offset', function () {
+      // 2025-04-28T01:00:00+05:00 = 2025-04-27T20:00:00Z
+      var result = formatDatetime('2025-04-28T01:00:00+05:00')
+      assert.equal(result.day, '27')
+      assert.equal(result.hours, '20')
+      assert.equal(result.date, '270425')
+    })
+
+    it('handles year boundary', function () {
+      // Dec 31 at 23:59:59 UTC
+      var result = formatDatetime('2025-12-31T23:59:59Z')
+      assert.equal(result.day, '31')
+      assert.equal(result.month, '12')
+      assert.equal(result.year, '2025')
+      assert.equal(result.date, '311225')
+    })
+
+    it('returns empty fields for invalid input', function () {
+      var empty = {
         date: '',
         day: '',
         hours: '',
         minutes: '',
         month: '',
         seconds: '',
+        centiseconds: '',
         time: '',
         year: ''
-      });
-      assert.deepEqual(formatDatetime(null), {
-        date: '',
-        day: '',
-        hours: '',
-        minutes: '',
-        month: '',
-        seconds: '',
-        time: '',
-        year: ''
-      });
-      assert.deepEqual(formatDatetime(undefined), {
-        date: '',
-        day: '',
-        hours: '',
-        minutes: '',
-        month: '',
-        seconds: '',
-        time: '',
-        year: ''
-      });
-    });
-  });
-});
+      }
+      assert.deepEqual(formatDatetime(1), empty)
+      assert.deepEqual(formatDatetime(null), empty)
+      assert.deepEqual(formatDatetime(undefined), empty)
+      assert.deepEqual(formatDatetime(''), empty)
+    })
+  })
+})

--- a/test/nmea.js
+++ b/test/nmea.js
@@ -1,5 +1,5 @@
-const assert = require('assert')
-const { toNmeaDegreesLatitude, toNmeaDegreesLongitude } = require('../nmea.js')
+const assert = require('assert');
+const { formatDatetime, toNmeaDegreesLatitude, toNmeaDegreesLongitude } = require('../nmea.js');
 
 describe('nmea', function () {
   describe('toNmeaDegreesLatitude()', function () {
@@ -94,3 +94,91 @@ describe('nmea', function () {
     })
   })
 })
+
+  describe('formatDatetime()', function () {
+    it('formats ISO datetime strings to NMEA0183 format', function () {
+      assert.deepEqual(formatDatetime('2025-04-27T12:34:56Z'), {
+        date: '270425',
+        day: '27',
+        hours: '12',
+        minutes: '34',
+        month: '04',
+        seconds: '56',
+        time: '123456',
+        year: '25'
+      });
+    });
+
+    it('handles timezones with +02:00 offset', function () {
+      assert.deepEqual(formatDatetime('2025-04-27T14:34:56+02:00'), {
+        date: '270425',
+        day: '27',
+        hours: '12',
+        minutes: '34',
+        month: '04',
+        seconds: '56',
+        time: '123456',
+        year: '25'
+      });
+    });
+
+    it('handles timezones with -05:00 offset', function () {
+      assert.deepEqual(formatDatetime('2025-04-27T07:34:56-05:00'), {
+        date: '270425',
+        day: '27',
+        hours: '12',
+        minutes: '34',
+        month: '04',
+        seconds: '56',
+        time: '123456',
+        year: '25'
+      });
+    });
+
+    it('handles timezones with +00:00 offset (UTC)', function () {
+      assert.deepEqual(formatDatetime('2025-04-27T12:34:56+00:00'), {
+        date: '270425',
+        day: '27',
+        hours: '12',
+        minutes: '34',
+        month: '04',
+        seconds: '56',
+        time: '123456',
+        year: '25'
+      });
+    });
+
+    it('returns empty', function () {
+      assert.deepEqual(formatDatetime(1), {
+        date: '',
+        day: '',
+        hours: '',
+        minutes: '',
+        month: '',
+        seconds: '',
+        time: '',
+        year: ''
+      });
+      assert.deepEqual(formatDatetime(null), {
+        date: '',
+        day: '',
+        hours: '',
+        minutes: '',
+        month: '',
+        seconds: '',
+        time: '',
+        year: ''
+      });
+      assert.deepEqual(formatDatetime(undefined), {
+        date: '',
+        day: '',
+        hours: '',
+        minutes: '',
+        month: '',
+        seconds: '',
+        time: '',
+        year: ''
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract shared `formatDatetime()` utility into `nmea.js` to consistently parse ISO 8601 datetime strings into NMEA0183 UTC time/date components
- Fix GLL sentence: was using local time (`getHours()`) instead of UTC (`getUTCHours()`) — this was the original bug reported in #96
- Refactor RMC, ZDA, and GGA to use the shared `formatDatetime()` instead of duplicated inline parsing
- Fix NMEA0183 time format: use actual centiseconds from input datetime instead of hardcoded `.020`
- ZDA now correctly outputs 4-digit year per spec

## Changes

- `nmea.js`: add `formatDatetime()` — parses ISO 8601 to `{ hours, minutes, seconds, centiseconds, time, day, month, year, date }` using UTC methods
- `sentences/GLL.js`: use `formatDatetime()` (fixes the UTC bug)
- `sentences/RMC.js`: use `formatDatetime()` (removes duplicated code)
- `sentences/GGA.js`: use `formatDatetime()` (removes duplicated code)
- `sentences/ZDA.js`: use `formatDatetime()` with full 4-digit year

## Test plan

- [x] Add `formatDatetime()` unit tests: UTC, timezone offsets (+02:00, -05:00, +00:00), fractional seconds, midnight, year boundary, day-crossing timezone, invalid inputs (number, null, undefined, empty string)
- [x] Add GLL sentence integration tests: UTC datetime, timezone offset (verifies the UTC fix), fractional seconds, null position
- [x] Add ZDA sentence integration tests: UTC datetime, timezone offset, day-crossing timezone, 4-digit year verification
- [x] Update GGA test expectations for new time format with centiseconds
- [x] All 28 tests passing