### PR TITLE
Align course related sentences  to course api Signal K paths

### DIFF
--- a/sentences/APB.js
+++ b/sentences/APB.js
@@ -50,7 +50,7 @@ module.exports = function (app) {
         '$IIAPB',
         'A',
         'A',
-        Math.abs(nmea.mToNm(xte)).toFixed(3),  // NMEA 0183 4.11 prescribes units must be the Nautical miles
+        Math.abs(nmea.mToNm(xte)).toFixed(3), // NMEA 0183 4.11 prescribes units must be the Nautical miles
         xte > 0 ? 'L' : 'R',
         'N',
         'V',

--- a/sentences/APB.js
+++ b/sentences/APB.js
@@ -40,10 +40,10 @@ module.exports = function (app) {
     sentence: 'APB',
     title: 'APB - Autopilot info',
     keys: [
-      'navigation.courseGreatCircle.crossTrackError',
-      'navigation.courseGreatCircle.bearingTrackTrue',
-      'navigation.courseGreatCircle.nextPoint.bearingTrue',
-      'navigation.courseGreatCircle.nextPoint.bearingMagnetic'
+      'navigation.course.calcValues.crossTrackError',
+      'navigation.course.calcValues.bearingTrackTrue',
+      'navigation.course.calcValues.bearingTrue',
+      'navigation.course.calcValues.bearingMagnetic'
     ],
     f: function (xte, originToDest, bearingTrue, bearingMagnetic) {
       return nmea.toSentence([

--- a/sentences/RMB.js
+++ b/sentences/RMB.js
@@ -23,17 +23,16 @@ module.exports = function (app) {
     ],
     f: function (
       crossTrackError,
-      wpLatitude,
-      wpLongitude,
+      wp,
       wpDistance,
       bearingTrue
     ) {
       return nmea.toSentence([
         '$IIRMB',
-        crossTrackError.toFixed(2),
+        Math.abs(nmea.mToNm(crossTrackError)).toFixed(3),
         crossTrackError < 0 ? 'R' : 'L',
-        nmea.toNmeaDegreesLatitude(wp.position.latitude),
-        nmea.toNmeaDegreesLongitude(wp.position.longitude),
+        nmea.toNmeaDegreesLatitude(wp.position?.latitude),
+        nmea.toNmeaDegreesLongitude(wp.position?.longitude),
         wpDistance.toFixed(2),
         nmea.radsToDeg(bearingTrue).toFixed(2),
         'V', // dont set the arrival flag as it will set of alarms.

--- a/sentences/RMB.js
+++ b/sentences/RMB.js
@@ -21,12 +21,7 @@ module.exports = function (app) {
       'navigation.course.calcValues.distance',
       'navigation.course.calcValues.bearingTrue'
     ],
-    f: function (
-      crossTrackError,
-      wp,
-      wpDistance,
-      bearingTrue
-    ) {
+    f: function (crossTrackError, wp, wpDistance, bearingTrue) {
       return nmea.toSentence([
         '$IIRMB',
         Math.abs(nmea.mToNm(crossTrackError)).toFixed(3),

--- a/sentences/RMB.js
+++ b/sentences/RMB.js
@@ -16,11 +16,10 @@ module.exports = function (app) {
     sentence: 'RMB',
     title: 'RMB - Heading and distance to waypoint',
     keys: [
-      'navigation.courseRhumbline.crossTrackError',
-      'resources.waypoints.next.position.latitude',
-      'resources.waypoints.next.position.longitude',
-      'navigation.courseRhumbline.nextPoint.distance',
-      'navigation.courseRhumbline.bearingTrue'
+      'navigation.course.calcValues.crossTrackError',
+      'navigation.course.nextPoint',
+      'navigation.course.calcValues.distance',
+      'navigation.course.calcValues.bearingTrue'
     ],
     f: function (
       crossTrackError,
@@ -33,8 +32,8 @@ module.exports = function (app) {
         '$IIRMB',
         crossTrackError.toFixed(2),
         crossTrackError < 0 ? 'R' : 'L',
-        nmea.toNmeaDegreesLatitude(wpLatitude),
-        nmea.toNmeaDegreesLongitude(wpLongitude),
+        nmea.toNmeaDegreesLatitude(wp.position.latitude),
+        nmea.toNmeaDegreesLongitude(wp.position.longitude),
         wpDistance.toFixed(2),
         nmea.radsToDeg(bearingTrue).toFixed(2),
         'V', // dont set the arrival flag as it will set of alarms.

--- a/sentences/XTE-GC.js
+++ b/sentences/XTE-GC.js
@@ -14,7 +14,7 @@ module.exports = function (app) {
         '$IIXTE',
         'A',
         'A',
-        nmea.mToNm(crossTrackError).toFixed(3),
+        Math.abs(nmea.mToNm(crossTrackError)).toFixed(3),
         crossTrackError < 0 ? 'R' : 'L',
         'N'
       ])

--- a/sentences/XTE.js
+++ b/sentences/XTE.js
@@ -8,7 +8,7 @@ const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {
     title: 'XTE - Cross-track error (w.r.t. Rhumb line)',
-    keys: [ 'navigation.course.calcValues.crossTrackError'],
+    keys: ['navigation.course.calcValues.crossTrackError'],
     f: function (crossTrackError) {
       return nmea.toSentence([
         '$IIXTE',

--- a/sentences/XTE.js
+++ b/sentences/XTE.js
@@ -8,13 +8,13 @@ const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {
     title: 'XTE - Cross-track error (w.r.t. Rhumb line)',
-    keys: ['navigation.courseRhumbline.crossTrackError'],
+    keys: [ 'navigation.course.calcValues.crossTrackError'],
     f: function (crossTrackError) {
       return nmea.toSentence([
         '$IIXTE',
         'A',
         'A',
-        nmea.mToNm(crossTrackError).toFixed(3),
+        Math.abs(nmea.mToNm(crossTrackError)).toFixed(3),
         crossTrackError < 0 ? 'R' : 'L',
         'N'
       ])


### PR DESCRIPTION
Update the following sentence types to use Course API paths:

**APB** changes:

- Updated source paths
> 'navigation.course.calcValues.crossTrackError',
> 'navigation.course.calcValues.bearingTrackTrue',
> 'navigation.course.calcValues.bearingTrue',
> 'navigation.course.calcValues.bearingMagnetic'

---

**RMB** changes:
- Updated source paths
> 'navigation.course.calcValues.crossTrackError',
> 'navigation.course.nextPoint',
>  'navigation.course.calcValues.distance',
>  'navigation.course.calcValues.bearingTrue'

- XTE value is converted to NM
- XTE value is an `absolute` value
- XTE value decimal precsion is now 3 _(was previously 2)_

---

**XTE** changes:

- Updated source path
> 'navigation.course.calcValues.crossTrackError'
- XTE value is an `absolute` value

---

**XTE-GC** changes:
- XTE value is an `absolute` value