### PR TITLE
Rearrange bearing output for NMEA sentence

### DIFF
--- a/sentences/APB.js
+++ b/sentences/APB.js
@@ -58,10 +58,10 @@ module.exports = function (app) {
         nmea.radsToPositiveDeg(originToDest).toFixed(0),
         'T',
         '00',
-        nmea.radsToPositiveDeg(bearingTrue).toFixed(0),
-        'T',
         nmea.radsToPositiveDeg(bearingMagnetic).toFixed(0),
-        'M'
+        'M',
+        nmea.radsToPositiveDeg(bearingTrue).toFixed(0),
+        'T'
       ])
     }
   }


### PR DESCRIPTION
Pypilot needs "T" in the field No14 to use navigation mode. I dont think this change becomes a problem. Its hardcoded anyway