### PR TITLE
Update VHW to work from navigation.headingMagnetic

### DIFF
--- a/sentences/VHW.js
+++ b/sentences/VHW.js
@@ -14,17 +14,17 @@ module.exports = function (app) {
     sentence: 'VHW',
     title: 'VHW - Speed and direction',
     keys: [
-      'navigation.headingTrue',
+      'navigation.headingMagnetic',
       'navigation.magneticVariation',
       'navigation.speedThroughWater'
     ],
-    f: function vhw (headingTrue, magneticVariation, speedThroughWater) {
-      var headingMagnetic = headingTrue + magneticVariation
-      if (headingMagnetic > Math.PI * 2) {
-        headingMagnetic -= Math.PI * 2
+    f: function vhw (headingMagnetic, magneticVariation, speedThroughWater) {
+      var headingTrue = headingMagnetic + magneticVariation
+      if (headingTrue > Math.PI * 2) {
+        headingTrue -= Math.PI * 2
       }
-      if (headingMagnetic < 0) {
-        headingMagnetic += Math.PI * 2
+      if (headingTrue < 0) {
+        headingTrue += Math.PI * 2
       }
       return nmea.toSentence([
         '$IIVHW',


### PR DESCRIPTION
navigation.headingMagnetic is available on minimal NMEA2000 based installations, the navigation.headingTrue is not generally available. Without the heading the conversion to generate VHW will fail.