### PR TITLE
style: apply prettier-standard formatting to index, nmea, and sentences

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,9 @@ module.exports = function (app) {
         }
         return stream
       }, app.streambundle)
-      const sentenceEvent = encoder.sentence ? `g${encoder.sentence}` : undefined
+      const sentenceEvent = encoder.sentence
+        ? `g${encoder.sentence}`
+        : undefined
 
       let stream = Bacon.combineWith(function () {
         try {
@@ -57,17 +59,16 @@ module.exports = function (app) {
       }
 
       plugin.unsubscribes.push(
-        stream
-          .onValue(nmeaString => {
-            if ( app.reportOutputMessages ) {
-              app.reportOutputMessages(1)
-            }
-            app.emit('nmea0183out', nmeaString)
-            if (sentenceEvent) {
-              app.emit(sentenceEvent, nmeaString)
-            }
-            app.debug(nmeaString)
-          })
+        stream.onValue(nmeaString => {
+          if (app.reportOutputMessages) {
+            app.reportOutputMessages(1)
+          }
+          app.emit('nmea0183out', nmeaString)
+          if (sentenceEvent) {
+            app.emit(sentenceEvent, nmeaString)
+          }
+          app.debug(nmeaString)
+        })
       )
     }
 
@@ -116,4 +117,4 @@ function loadSentences (app, plugin) {
     }, {})
 }
 
-const getThrottlePropname = (key) => `${key}_throttle`
+const getThrottlePropname = key => `${key}_throttle`

--- a/nmea.js
+++ b/nmea.js
@@ -41,15 +41,15 @@ function toHexString (v) {
 }
 
 function radsToDeg (radians) {
-  return radians * 180 / Math.PI
+  return (radians * 180) / Math.PI
 }
 
 function msToKnots (v) {
-  return v * 3600 / 1852.0
+  return (v * 3600) / 1852.0
 }
 
 function msToKM (v) {
-  return v * 3600.0 / 1000.0
+  return (v * 3600.0) / 1000.0
 }
 
 function mToNm (v) {
@@ -62,7 +62,7 @@ function padd (n, p, c) {
   return (pad + n).slice(-pad.length)
 }
 
-function decimalDegreesToDegreesAndDecimalMinutes ( degrees ) {
+function decimalDegreesToDegreesAndDecimalMinutes (degrees) {
   /*
     decimalDegreesToDegreesAndDecimalMinutes takes a float (degrees)
     representing decimal degrees and returns a tuple [deg, min, dir], where
@@ -73,16 +73,16 @@ function decimalDegreesToDegreesAndDecimalMinutes ( degrees ) {
     NOTE: 0 degrees is N or E
   */
 
-  let dir=1 // default to N or E
+  let dir = 1 // default to N or E
 
-  if (degrees<0) {
+  if (degrees < 0) {
     dir = -1
     degrees *= -1
   }
 
   let degrees_out = Math.floor(degrees)
   let minutes = (degrees % 1) * 60
-  return [ degrees_out, minutes, dir ]
+  return [degrees_out, minutes, dir]
 }
 
 function toNmeaDegreesLatitude (inVal) {
@@ -93,16 +93,17 @@ function toNmeaDegreesLatitude (inVal) {
   */
 
   if (typeof inVal != 'number' || inVal < -90 || inVal > 90) {
-    throw new Error("invalid input to toNmeaDegreesLatitude: " + inVal)
+    throw new Error('invalid input to toNmeaDegreesLatitude: ' + inVal)
   }
 
   let [degrees, minutes, dir] = decimalDegreesToDegreesAndDecimalMinutes(inVal)
 
-  return(
-      padd(degrees.toFixed(0), 2)
-      + padd(minutes.toFixed(4), 7)
-      + "," + (dir > 0 ? "N" : "S")
-    )
+  return (
+    padd(degrees.toFixed(0), 2) +
+    padd(minutes.toFixed(4), 7) +
+    ',' +
+    (dir > 0 ? 'N' : 'S')
+  )
 }
 
 function toNmeaDegreesLongitude (inVal) {
@@ -113,16 +114,17 @@ function toNmeaDegreesLongitude (inVal) {
   */
 
   if (typeof inVal != 'number' || inVal <= -180 || inVal > 180) {
-    throw new Error("invalid input to toNmeaDegreesLongitude: " + inVal)
+    throw new Error('invalid input to toNmeaDegreesLongitude: ' + inVal)
   }
 
   let [degrees, minutes, dir] = decimalDegreesToDegreesAndDecimalMinutes(inVal)
 
-  return(
-      padd(degrees.toFixed(0), 3)
-      + padd(minutes.toFixed(4), 7)
-      + "," + (dir > 0 ? "E" : "W")
-    )
+  return (
+    padd(degrees.toFixed(0), 3) +
+    padd(minutes.toFixed(4), 7) +
+    ',' +
+    (dir > 0 ? 'E' : 'W')
+  )
 }
 
 function fixAngle (d) {
@@ -136,7 +138,7 @@ function toPositiveRadians (d) {
   return d < 0 ? d + 2 * Math.PI : d
 }
 
-function radsToPositiveDeg(r) {
+function radsToPositiveDeg (r) {
   return radsToDeg(toPositiveRadians(r))
 }
 

--- a/sentences/GGA.js
+++ b/sentences/GGA.js
@@ -55,11 +55,24 @@ module.exports = function (app) {
       null, // navigation.gnss.differentialAge (= Age of differential GPS data record, Type 1 or Type 9. Null field when DGPS is not used)
       null // navigation.gnss.differentialReference (= Reference station ID, range 0000-4095. A null field when any reference station ID is selected and no corrections are received)
     ],
-    f: function (datetime8601, position, gnssMethodQuality, gnssSatellites, gnssHorizontalDilution, gnssAntennaAltitude, gnssgeoidalSeparation, gnssDifferentialAge, gnssDifferentialReference) {
+    f: function (
+      datetime8601,
+      position,
+      gnssMethodQuality,
+      gnssSatellites,
+      gnssHorizontalDilution,
+      gnssAntennaAltitude,
+      gnssgeoidalSeparation,
+      gnssDifferentialAge,
+      gnssDifferentialReference
+    ) {
       let time = ''
       let ignssMethodQuality = 0
 
-      if (!datetime8601 || (typeof datetime8601 === 'string' && datetime8601.trim() === '')) {
+      if (
+        !datetime8601 ||
+        (typeof datetime8601 === 'string' && datetime8601.trim() === '')
+      ) {
         datetime8601 = new Date().toISOString()
       }
 
@@ -85,33 +98,33 @@ module.exports = function (app) {
       }
 
       switch (gnssMethodQuality) {
-         case 'no GPS' :
-           ignssMethodQuality = 0
-           break
-         case 'GNSS Fix' :
-           ignssMethodQuality = 1
-           break
-         case 'DGNSS fix' :
-           ignssMethodQuality = 2
-           break
-         case 'Precise GNSS' :
-           ignssMethodQuality = 3
-           break
-         case 'RTK fixed integer' :
-           ignssMethodQuality = 4
-           break
-         case 'RTK float' :
-           ignssMethodQuality = 5
-           break
-         case 'Estimated (DR) mode' :
-           ignssMethodQuality = 6
-           break
-         case 'Manual input' :
-           ignssMethodQuality = 7
-           break
-         case 'Simulator mode' :
-           ignssMethodQuality = 8
-           break
+        case 'no GPS':
+          ignssMethodQuality = 0
+          break
+        case 'GNSS Fix':
+          ignssMethodQuality = 1
+          break
+        case 'DGNSS fix':
+          ignssMethodQuality = 2
+          break
+        case 'Precise GNSS':
+          ignssMethodQuality = 3
+          break
+        case 'RTK fixed integer':
+          ignssMethodQuality = 4
+          break
+        case 'RTK float':
+          ignssMethodQuality = 5
+          break
+        case 'Estimated (DR) mode':
+          ignssMethodQuality = 6
+          break
+        case 'Manual input':
+          ignssMethodQuality = 7
+          break
+        case 'Simulator mode':
+          ignssMethodQuality = 8
+          break
       }
 
       return toSentence([

--- a/sentences/HDG.js
+++ b/sentences/HDG.js
@@ -10,13 +10,13 @@ module.exports = function (app) {
   return {
     sentence: 'HDG',
     title: 'HDG - Heading magnetic:.',
-    keys: ['navigation.headingMagnetic', 'navigation.magneticVariation' ],
+    keys: ['navigation.headingMagnetic', 'navigation.magneticVariation'],
     defaults: [undefined, ''],
     f: function hdg (headingMagnetic, magneticVariation) {
       var magneticVariationDir = ''
-      if ( magneticVariation != '' ) {
+      if (magneticVariation != '') {
         magneticVariationDir = 'E'
-        if ( headingMagnetic < 0 ) {
+        if (headingMagnetic < 0) {
           magneticVariationDir = 'W'
           magneticVariation = Math.abs(magneticVariation)
         }

--- a/sentences/HDTC.js
+++ b/sentences/HDTC.js
@@ -4,11 +4,11 @@ module.exports = function (app) {
   return {
     sentence: 'HDTC',
     title: 'HDT - Heading True calculated from magnetic heading and variation',
-    keys: ['navigation.headingMagnetic', 'navigation.magneticVariation' ],
+    keys: ['navigation.headingMagnetic', 'navigation.magneticVariation'],
     f: function (headingMagnetic, magneticVariation) {
       var heading = headingMagnetic + magneticVariation
       if (heading > 2 * Math.PI) heading -= 2 * Math.PI
-      else if (heading < 0 ) heading += 2 * Math.PI
+      else if (heading < 0) heading += 2 * Math.PI
       return nmea.toSentence([
         '$IIHDT',
         nmea.radsToDeg(heading).toFixed(1),

--- a/sentences/PSILCD1.js
+++ b/sentences/PSILCD1.js
@@ -13,10 +13,15 @@ Field Number:
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {
-    title: 'PSILCD1 - Send polar speed and target wind angle to Silva/Nexus/Garmin displays',
+    title:
+      'PSILCD1 - Send polar speed and target wind angle to Silva/Nexus/Garmin displays',
     keys: ['performance.polarSpeed', 'performance.targetAngle'],
     f: function (polarSpeed, targetAngle) {
-      return nmea.toSentence(['$PSILCD1', nmea.msToKnots(polarSpeed).toFixed(2), nmea.radsToDeg(targetAngle).toFixed(2)])
+      return nmea.toSentence([
+        '$PSILCD1',
+        nmea.msToKnots(polarSpeed).toFixed(2),
+        nmea.radsToDeg(targetAngle).toFixed(2)
+      ])
     }
   }
 }

--- a/sentences/RMB.js
+++ b/sentences/RMB.js
@@ -36,7 +36,7 @@ module.exports = function (app) {
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.calcValues.velocityMadeGood'
     ],
-    f: function (crossTrackError, wp, wpDistance, bearingTrue,vmg) {
+    f: function (crossTrackError, wp, wpDistance, bearingTrue, vmg) {
       return nmea.toSentence([
         '$IIRMB',
         'A',

--- a/sentences/RMC.js
+++ b/sentences/RMC.js
@@ -24,7 +24,12 @@
 // This needs to run faster that others.
 
 // NMEA0183 Encoder RMC   $INRMC,200152.020,A,5943.2980,N,2444.1043,E,6.71,194.30,0000,8.1,E*40
-const { toSentence, toNmeaDegreesLatitude, toNmeaDegreesLongitude, radsToDeg } = require('../nmea.js')
+const {
+  toSentence,
+  toNmeaDegreesLatitude,
+  toNmeaDegreesLongitude,
+  radsToDeg
+} = require('../nmea.js')
 module.exports = function (app) {
   return {
     sentence: 'RMC',
@@ -53,9 +58,9 @@ module.exports = function (app) {
         date = day + month + year
       }
       var magneticVariationDir = 'E'
-      if ( magneticVariation < 0 ) {
-        magneticVariationDir = 'W';
-        magneticVariation = magneticVariation * -1;
+      if (magneticVariation < 0) {
+        magneticVariationDir = 'W'
+        magneticVariation = magneticVariation * -1
       }
       return toSentence([
         '$GPRMC',
@@ -66,7 +71,9 @@ module.exports = function (app) {
         (sog * 1.94384).toFixed(1),
         radsToDeg(cog).toFixed(1),
         date,
-        typeof magneticVariation === 'number' ? radsToDeg(magneticVariation).toFixed(1) : magneticVariation,
+        typeof magneticVariation === 'number'
+          ? radsToDeg(magneticVariation).toFixed(1)
+          : magneticVariation,
         magneticVariationDir
       ])
     }

--- a/sentences/VPW.js
+++ b/sentences/VPW.js
@@ -11,9 +11,7 @@ module.exports = function (app) {
   return {
     sentence: 'VPW',
     title: 'VPW - Speed – Measured Parallel to Wind',
-    keys: [
-      'performance.velocityMadeGood'
-    ],
+    keys: ['performance.velocityMadeGood'],
     f: function vpw (velocityMadeGood) {
       return nmea.toSentence([
         '$IIVPW',


### PR DESCRIPTION
## Summary

The functional baconjs 1.x → 3.x upgrade has already landed on master via 74e44b4 (move to `peerDependencies`, `stream.toProperty(default)` in place of `stream.merge(Bacon.once(default))`).

Rebased onto current master and squashed; the remaining change is a pure cosmetic pass running the existing `prettier-standard` config over the files the original branch touched (`index.js`, `nmea.js`, and the affected sentence modules). No behavior changes.

## Testing

- `npm test`: all 20 tests pass
- Manual test log from the original PR still applies (live Signal K server v2.23.0 with YDWG02 N2K gateway; GGA/GLL/HDT/HDG/HDM/HDMC/DPT/DPT-surface/DBS/DBT/DBK/MTW/MWD/ROT/RMB/APB/PSILCD1 all emit correctly from live N2K data)
