### PR TITLE
fix: VWT wind angle must be 0-180 with L/R indicator

### DIFF
--- a/sentences/VWT.js
+++ b/sentences/VWT.js
@@ -15,10 +15,17 @@ module.exports = function (app) {
     title: 'VWT - True wind speed relative to boat.',
     keys: ['environment.wind.angleTrueWater', 'environment.wind.speedTrue'],
     f: function (angleTrueWater, speedTrue) {
+      // environment.wind.angleTrueWater is signed radians, negative to port.
+      // NMEA 0183 VWT expects magnitude 0..180 followed by L/R.
+      var windDirection = 'R'
+      if (angleTrueWater < 0) {
+        angleTrueWater = -angleTrueWater
+        windDirection = 'L'
+      }
       return nmea.toSentence([
         '$IIVWT',
         nmea.radsToDeg(angleTrueWater).toFixed(2),
-        'a',
+        windDirection,
         nmea.msToKnots(speedTrue).toFixed(2),
         'N',
         speedTrue.toFixed(2),

--- a/test/VWT.js
+++ b/test/VWT.js
@@ -60,4 +60,77 @@ describe('VWT', function () {
     const app = createAppWithPlugin(onEmit, 'VWT')
     pushVWT(app, Math.PI / 2, 5.14)
   })
+
+  // Regression tests for SignalK/signalk-to-nmea0183#36.
+  // NMEA 0183 VWT expects a magnitude 0..180 followed by L (port) or R
+  // (starboard). Signal K delivers environment.wind.angleTrueWater as
+  // signed radians, negative to port (see specification/schemas/groups/
+  // environment.json). The encoder must map the sign to L/R and emit the
+  // absolute angle in degrees, not the raw signed value.
+
+  it('reports starboard wind with R and a positive angle', done => {
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[1], '45.00')
+      assert.equal(parts[2], 'R')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VWT')
+    pushVWT(app, Math.PI / 4, 2)
+  })
+
+  it('reports port wind with L and a positive angle', done => {
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[1], '45.00')
+      assert.equal(parts[2], 'L')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VWT')
+    pushVWT(app, -Math.PI / 4, 2)
+  })
+
+  it('reports head-on wind (0 rad) with a 0 angle and R', done => {
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[1], '0.00')
+      assert.equal(parts[2], 'R')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VWT')
+    pushVWT(app, 0, 2)
+  })
+
+  it('reports astern wind (pi rad) with a 180 angle', done => {
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[1], '180.00')
+      assert.match(parts[2], /^[LR]$/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VWT')
+    pushVWT(app, Math.PI, 2)
+  })
+
+  it('reports beam wind 90deg starboard with R', done => {
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[1], '90.00')
+      assert.equal(parts[2], 'R')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VWT')
+    pushVWT(app, Math.PI / 2, 2)
+  })
+
+  it('reports beam wind 90deg port with L', done => {
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[1], '90.00')
+      assert.equal(parts[2], 'L')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VWT')
+    pushVWT(app, -Math.PI / 2, 2)
+  })
 })

--- a/test/VWT.js
+++ b/test/VWT.js
@@ -1,0 +1,63 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+// Parse the comma-separated body of an NMEA sentence and strip the checksum
+// from the final field.
+// Input:  "$IIVWT,90.00,R,3.89,N,2.00,M,7.20,K*73"
+// Output: ["$IIVWT", "90.00", "R", "3.89", "N", "2.00", "M", "7.20", "K"]
+function parseSentence (sentence) {
+  const star = sentence.indexOf('*')
+  const body = star >= 0 ? sentence.substring(0, star) : sentence
+  return body.split(',')
+}
+
+function pushVWT (app, angleRad, speedMs) {
+  app.streambundle
+    .getSelfStream('environment.wind.angleTrueWater')
+    .push(angleRad)
+  app.streambundle.getSelfStream('environment.wind.speedTrue').push(speedMs)
+}
+
+describe('VWT', function () {
+  it('emits a VWT sentence with the expected layout', done => {
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[0], '$IIVWT')
+      assert.equal(parts.length, 9, 'expected 9 comma-separated fields')
+      assert.equal(parts[4], 'N')
+      assert.equal(parts[6], 'M')
+      assert.equal(parts[8], 'K')
+      assert.match(value, /\*[0-9A-F]{2}$/, 'expected trailing *HH checksum')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VWT')
+    pushVWT(app, Math.PI / 2, 2)
+  })
+
+  it('converts true wind speed to knots, m/s and km/h', done => {
+    // 2 m/s -> 3.89 kn, 2.00 m/s, 7.20 km/h
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[3], '3.89')
+      assert.equal(parts[5], '2.00')
+      assert.equal(parts[7], '7.20')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VWT')
+    pushVWT(app, Math.PI / 2, 2)
+  })
+
+  it('handles a different speed value', done => {
+    // 5.14 m/s ~ 10 knots
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[3], '9.99')
+      assert.equal(parts[5], '5.14')
+      assert.equal(parts[7], '18.50')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VWT')
+    pushVWT(app, Math.PI / 2, 5.14)
+  })
+})


### PR DESCRIPTION
## Summary
- VWT encoder emitted the raw signed degree value from `environment.wind.angleTrueWater` and a literal `'a'` placeholder. NMEA 0183 VWT requires a magnitude in `[0, 180]` followed by `L` (port) or `R` (starboard), so downstream parsers could not interpret the sentence correctly (e.g. `$IIVWT,347.43,a,...` for a port-side wind).
- Added full test coverage for the VWT sentence and fixed the encoder. The fix mirrors the pattern already used by `VWR.js` for apparent wind.

Fixes #36.

## Commits
1. `test: add baseline coverage tests for VWT sentence` -- layout, speed conversion, alternate speed value (passes against current code).
2. `test: reproduce VWT wind angle/direction bug` -- six new cases across the angle equivalence classes (starboard, port, head-on, astern, beam-starboard, beam-port). Fails against current code, reproducing #36.
3. `fix: emit VWT wind angle as 0-180 with L/R indicator` -- maps the sign of `angleTrueWater` to `L`/`R` and emits the absolute angle.

## Test plan
- [x] `npx mocha` passes locally (20/20)
- [x] `$IIVWT,45.00,L,...` for `angleTrueWater = -pi/4`
- [x] `$IIVWT,45.00,R,...` for `angleTrueWater = +pi/4`
- [x] `$IIVWT,0.00,R,...` for head-on, `$IIVWT,180.00,R,...` for astern