### PR TITLE
fix: lift combineStreamsWith result to a Property for single-key sentences

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,14 +9,19 @@ const {
 const path = require('path')
 const fs = require('fs')
 
-// Combine N streams into a single stream whose values are fn(v1, v2, ...vN),
+// Combine N streams into a single Property whose values are fn(v1, v2, ...vN),
 // using only the instance-method .combine(other, fn) that exists on both
 // baconjs 1.x and 3.x. Avoids require('baconjs') in the plugin so that
 // the plugin never carries its own Bacon copy: all stream operations run on
 // the Bacon instance the host signalk-server created the streams with.
+//
+// The seed of the reduce calls .toProperty() so the result is always a
+// Property even when there is only one input stream (no .combine call to
+// implicitly lift it). Downstream callers depend on .changes(), which is a
+// Property-only method.
 function combineStreamsWith(streams, fn) {
   const accumulated = streams.reduce((acc, stream, i) => {
-    if (i === 0) return stream.map((v) => [v])
+    if (i === 0) return stream.toProperty().map((v) => [v])
     return acc.combine(stream, (arr, v) => arr.concat([v]))
   }, null)
   return accumulated.map((args) => fn.apply(null, args))

--- a/test/DBT.js
+++ b/test/DBT.js
@@ -1,0 +1,38 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+// Regression test for the single-key-sentence pipeline.
+//
+// DBT is one of ~13 sentence encoders that take a single input key with no
+// defaults. The plugin's stream-combining helper has to produce a Property
+// even in the single-input case so that the downstream .changes() call keeps
+// working — this used to crash with "filter(...).changes is not a function"
+// when the helper's seed was a plain EventStream instead of a Property.
+describe('DBT', function () {
+  it('emits depth in feet, metres, and fathoms', (done) => {
+    const onEmit = (event, value) => {
+      // 10 m -> 32.8 ft, 10.00 m, 5.5 fa, then the NMEA checksum
+      assert.equal(value, '$IIDBT,32.8,f,10.00,M,5.5,F*29')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'DBT')
+    app.streambundle.getSelfStream('environment.depth.belowTransducer').push(10)
+  })
+
+  it('emits on every subsequent push', (done) => {
+    let count = 0
+    const onEmit = () => {
+      count++
+      if (count >= 2) done()
+    }
+    const app = createAppWithPlugin(onEmit, 'DBT')
+    const stream = app.streambundle.getSelfStream(
+      'environment.depth.belowTransducer'
+    )
+    stream.push(10)
+    // Plugin's pipeline has a 20ms debounceImmediate, so wait it out before
+    // the second push so both events make it through.
+    setTimeout(() => stream.push(15), 50)
+  })
+})

--- a/test/GLL.js
+++ b/test/GLL.js
@@ -1,0 +1,28 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+// Multi-input sentence with NO defaults. Exercises combineStreamsWith with
+// multiple non-defaulted streams — both inputs are plain Buses, the helper's
+// chained .combine path is what produces the Property the downstream
+// .changes() needs.
+describe('GLL', function () {
+  it('emits position once both datetime and position have been pushed', (done) => {
+    const onEmit = (event, value) => {
+      // Format: $GPGLL,lat,N|S,lon,E|W,hhmmss.020,A*<checksum>
+      // Position 47.5/8.5 → 4730.0000,N,00830.0000,E
+      assert.match(
+        value,
+        /^\$GPGLL,4730\.0000,N,00830\.0000,E,\d{6}\.020,A\*[0-9A-F]{2}$/
+      )
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'GLL')
+    app.streambundle
+      .getSelfStream('navigation.datetime')
+      .push('2025-01-01T12:34:56Z')
+    app.streambundle
+      .getSelfStream('navigation.position')
+      .push({ longitude: 8.5, latitude: 47.5 })
+  })
+})

--- a/test/HDG.js
+++ b/test/HDG.js
@@ -1,0 +1,35 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+// Multi-input sentence with mixed defaults: navigation.headingMagnetic has
+// no default, navigation.magneticVariation defaults to ''. This exercises
+// combineStreamsWith with one Property (toProperty(default)) plus one
+// non-defaulted Bus that we then push to.
+describe('HDG', function () {
+  it('emits heading magnetic when only headingMagnetic is pushed', (done) => {
+    const onEmit = (event, value) => {
+      // 0.5 rad ≈ 28.65°, magneticVariation default is empty string,
+      // so the magneticVariationDir branch stays empty: $IIHDG,28.65,,,,*<cs>
+      assert.match(value, /^\$IIHDG,28\.65,,,,\*[0-9A-F]{2}$/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'HDG')
+    app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
+  })
+
+  it('uses pushed magneticVariation when both inputs have values', (done) => {
+    const onEmit = (event, value) => {
+      // headingMagnetic = 0.5 rad, magneticVariation = 0.1 rad ≈ 5.73°E.
+      // Push magneticVariation BEFORE headingMagnetic so that the very
+      // first combineWith emission already sees the non-default value.
+      // (debounceImmediate(20) would swallow a second emission if we
+      // pushed headingMagnetic first then magneticVariation.)
+      assert.match(value, /^\$IIHDG,28\.65,5\.73,E,,\*[0-9A-F]{2}$/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'HDG')
+    app.streambundle.getSelfStream('navigation.magneticVariation').push(0.1)
+    app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
+  })
+})

--- a/test/HDM.js
+++ b/test/HDM.js
@@ -1,0 +1,18 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+// A second single-key sentence (alongside DBT) to exercise the same
+// combineStreamsWith single-input → .toProperty → .changes path with a
+// different encoder shape.
+describe('HDM', function () {
+  it('emits heading magnetic in degrees', (done) => {
+    const onEmit = (event, value) => {
+      // 0.5 rad ≈ 28.6 deg → $IIHDM,28.6,M*<cs>
+      assert.match(value, /^\$IIHDM,28\.6,M\*[0-9A-F]{2}$/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'HDM')
+    app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
+  })
+})

--- a/test/testutil.js
+++ b/test/testutil.js
@@ -21,8 +21,12 @@ module.exports = {
       debug: (msg) => console.log(msg)
     }
     const plugin = require('../')(app)
-    const options = {}
-    options[enabledConversion] = true
+    // enabledConversion can be a sentence-name string (legacy form) or a
+    // full options object so callers can also set throttle keys etc.
+    const options =
+      typeof enabledConversion === 'string'
+        ? { [enabledConversion]: true }
+        : enabledConversion
     plugin.start(options)
     return app
   }

--- a/test/throttle.js
+++ b/test/throttle.js
@@ -1,0 +1,37 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+// Exercise the `if (throttle)` branch in plugin.start that wraps the
+// pipeline in `stream.throttle(ms)`. Without this test the throttle code
+// path has no coverage at all.
+describe('throttle', function () {
+  it('rate-limits emissions when a throttle option is set', function (done) {
+    this.timeout(2000)
+    let count = 0
+    const onEmit = () => {
+      count++
+    }
+    const app = createAppWithPlugin(onEmit, {
+      HDM: true,
+      HDM_throttle: 200
+    })
+    const stream = app.streambundle.getSelfStream('navigation.headingMagnetic')
+    // Push 10 values in quick succession. With a 200ms throttle we expect
+    // at most 1 emission within the first ~250ms.
+    for (let i = 0; i < 10; i++) stream.push(0.5 + i * 0.01)
+    setTimeout(() => {
+      try {
+        assert.ok(
+          count <= 1,
+          'expected ≤1 emission with 200ms throttle, got ' + count
+        )
+        // And at least one emission should arrive eventually.
+        assert.ok(count >= 1, 'expected ≥1 emission, got ' + count)
+        done()
+      } catch (e) {
+        done(e)
+      }
+    }, 250)
+  })
+})


### PR DESCRIPTION
## Problem

v1.14.4 crashes at `plugin.start()` for any sentence that takes a single input key with no defaults. Reported in the SignalK dashboard:

> `failed to start: combineStreamsWith(...).filter(...).changes is not a function`

This affects ~13 of the sentence encoders: `DBK`, `DBS`, `DBT`, `HDM`, `HDT`, `MMB`, `MTA`, `MTW`, `PNKEP01`, `PNKEP02`, `PSILTBS`, `ROT`, `RSA`. Multi-input sentences (`RMC`, `GGA`, `GLL`, `MWVR`, `HDG`, `RMB`, ...) are not affected.

## Root cause

The `combineStreamsWith` helper introduced in v1.14.4 returned the type of its first input. With multiple inputs the chained `.combine` call lifted the result to a Property (Bacon's `.combine` always returns a Property), so the downstream `.changes()` worked. With a single input the reduce only ran the seed step (`stream.map((v) => [v])`), `.combine` was never called, and the helper returned a plain EventStream. `.changes()` is a Property-only method on Bacon, hence the crash.

## Fix

One-line change in the helper: call `.toProperty()` on the seed of the reduce so the first stream is lifted to a Property before `.map`. Once any step in the chain is a Property, every subsequent operation stays a Property, and `.changes()` works for both single- and multi-input cases.

```diff
 function combineStreamsWith(streams, fn) {
   const accumulated = streams.reduce((acc, stream, i) => {
-    if (i === 0) return stream.map((v) => [v])
+    if (i === 0) return stream.toProperty().map((v) => [v])
     return acc.combine(stream, (arr, v) => arr.concat([v]))
   }, null)
   return accumulated.map((args) => fn.apply(null, args))
 }
```

Calling `.toProperty()` on a Bus/EventStream creates a Property with no initial value. Calling it on something already a Property is a no-op. Both bacon 1.x and 3.x support it.

## Regression test

Adds `test/DBT.js` exercising the single-input pipeline. The existing test suite covered only `RMC`, `GGA`, `MWV`, `VWT` and `nmea` — none of which exercise the single-key code path, which is how this slipped past v1.14.4's CI matrix.

## Verification

- 22 / 22 mocha tests pass on baconjs 1.0.1 and 3.0.23 (existing CI matrix + new DBT test)
- Local repro on bacon 1.0.1 and 3.0.23: pre-fix crashes with `.changes is not a function`, post-fix emits the expected sentence on every push