### PR TITLE
fix: correct magnetic variation sign in VHW and HDMC

### DIFF
--- a/sentences/HDMC.js
+++ b/sentences/HDMC.js
@@ -6,7 +6,7 @@ module.exports = function (app) {
     title: 'HDM - Heading Magnetic, calculated from True',
     keys: ['navigation.headingTrue', 'navigation.magneticVariation'],
     f: function (headingTrue, magneticVariation) {
-      var heading = headingTrue + magneticVariation
+      var heading = headingTrue - magneticVariation
       return nmea.toSentence([
         '$IIHDM',
         nmea.radsToDeg(heading).toFixed(1),

--- a/sentences/VHW.js
+++ b/sentences/VHW.js
@@ -19,7 +19,7 @@ module.exports = function (app) {
       'navigation.speedThroughWater'
     ],
     f: function vhw(headingTrue, magneticVariation, speedThroughWater) {
-      var headingMagnetic = headingTrue + magneticVariation
+      var headingMagnetic = headingTrue - magneticVariation
       if (headingMagnetic > Math.PI * 2) {
         headingMagnetic -= Math.PI * 2
       }

--- a/test/HDMC.js
+++ b/test/HDMC.js
@@ -1,0 +1,22 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+// HDMC generates HDM (magnetic heading) from headingTrue and magneticVariation.
+// Per the Signal K spec: headingTrue = headingMagnetic + magneticVariation,
+// therefore: headingMagnetic = headingTrue - magneticVariation.
+describe('HDMC', function () {
+  it('computes magnetic heading by subtracting variation from true heading', (done) => {
+    // headingTrue = pi rad = 180 deg, variation = 10 deg easterly
+    // Expected: headingMagnetic = 180 - 10 = 170 deg
+    const onEmit = (event, value) => {
+      assert.match(value, /^\$IIHDM,170\.0,M\*[0-9A-F]{2}$/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'HDMC')
+    app.streambundle
+      .getSelfStream('navigation.magneticVariation')
+      .push((10 * Math.PI) / 180)
+    app.streambundle.getSelfStream('navigation.headingTrue').push(Math.PI)
+  })
+})

--- a/test/VHW.js
+++ b/test/VHW.js
@@ -1,0 +1,76 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+// VHW encodes true heading, magnetic heading (derived from true heading minus
+// magneticVariation), and speed through water.
+//
+// Per the Signal K spec, magneticVariation "must be added to the magnetic
+// heading to derive the true heading":
+//   headingTrue = headingMagnetic + magneticVariation
+// Therefore:
+//   headingMagnetic = headingTrue - magneticVariation
+describe('VHW', function () {
+  it('computes magnetic heading by subtracting variation from true heading', (done) => {
+    // headingTrue = pi rad = 180 deg
+    // magneticVariation = 10 deg easterly (positive per spec)
+    // Expected: headingMagnetic = 180 - 10 = 170 deg
+    // speedThroughWater = 10 knots = 10 * 1852/3600 m/s
+    const onEmit = (event, value) => {
+      assert.match(
+        value,
+        /^\$IIVHW,180\.0,T,170\.0,M,10\.00,N,18\.52,K\*[0-9A-F]{2}$/
+      )
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VHW')
+    const headingTrue = Math.PI
+    const magneticVariation = (10 * Math.PI) / 180
+    const speedThroughWater = (10 * 1852) / 3600
+    app.streambundle.getSelfStream('navigation.headingTrue').push(headingTrue)
+    app.streambundle
+      .getSelfStream('navigation.magneticVariation')
+      .push(magneticVariation)
+    app.streambundle
+      .getSelfStream('navigation.speedThroughWater')
+      .push(speedThroughWater)
+  })
+
+  it('wraps magnetic heading into [0, 360) when variation pushes it negative', (done) => {
+    // headingTrue = 5 deg, variation = 10 deg easterly
+    // headingMagnetic = 5 - 10 = -5 deg -> wraps to 355 deg
+    const onEmit = (event, value) => {
+      assert.match(value, /^\$IIVHW,5\.0,T,355\.0,M/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VHW')
+    app.streambundle
+      .getSelfStream('navigation.headingTrue')
+      .push((5 * Math.PI) / 180)
+    app.streambundle
+      .getSelfStream('navigation.magneticVariation')
+      .push((10 * Math.PI) / 180)
+    app.streambundle
+      .getSelfStream('navigation.speedThroughWater')
+      .push((10 * 1852) / 3600)
+  })
+
+  it('wraps magnetic heading into [0, 360) when variation pushes it above 360', (done) => {
+    // headingTrue = 355 deg, variation = -10 deg (westerly)
+    // headingMagnetic = 355 - (-10) = 365 deg -> wraps to 5 deg
+    const onEmit = (event, value) => {
+      assert.match(value, /^\$IIVHW,355\.0,T,5\.0,M/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VHW')
+    app.streambundle
+      .getSelfStream('navigation.headingTrue')
+      .push((355 * Math.PI) / 180)
+    app.streambundle
+      .getSelfStream('navigation.magneticVariation')
+      .push((-10 * Math.PI) / 180)
+    app.streambundle
+      .getSelfStream('navigation.speedThroughWater')
+      .push((10 * 1852) / 3600)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the magnetic variation sign in VHW and HDMC sentence encoders.

The Signal K spec defines `navigation.magneticVariation` as the value that "must be added to the magnetic heading to derive the true heading":
```
headingTrue = headingMagnetic + magneticVariation
```

To compute magnetic heading from true heading, the variation must be **subtracted**:
```
headingMagnetic = headingTrue - magneticVariation
```

Both VHW and HDMC were incorrectly **adding** the variation, producing magnetic headings offset in the wrong direction.

Closes #63

## Test plan

- Added `test/VHW.js` with three cases: basic easterly variation, wrapping below 0 deg, wrapping above 360 deg
- Added `test/HDMC.js` verifying the same sign correction
- Full test suite passes (52 tests)