### PR TITLE
fix: check magneticVariation instead of headingMagnetic for HDG direction

### DIFF
--- a/sentences/HDG.js
+++ b/sentences/HDG.js
@@ -16,7 +16,7 @@ module.exports = function (app) {
       var magneticVariationDir = ''
       if (magneticVariation != '') {
         magneticVariationDir = 'E'
-        if (headingMagnetic < 0) {
+        if (magneticVariation < 0) {
           magneticVariationDir = 'W'
           magneticVariation = Math.abs(magneticVariation)
         }

--- a/test/HDG.js
+++ b/test/HDG.js
@@ -32,4 +32,16 @@ describe('HDG', function () {
     app.streambundle.getSelfStream('navigation.magneticVariation').push(0.1)
     app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
   })
+
+  it('reports westerly variation with W direction and positive degrees', (done) => {
+    // magneticVariation = -0.1 rad (westerly, negative per Signal K spec)
+    // Expected: direction = 'W', degrees = 5.73 (absolute value)
+    const onEmit = (event, value) => {
+      assert.match(value, /^\$IIHDG,28\.65,5\.73,W,,\*[0-9A-F]{2}$/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'HDG')
+    app.streambundle.getSelfStream('navigation.magneticVariation').push(-0.1)
+    app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
+  })
 })


### PR DESCRIPTION
## Summary

Fixes the variation direction (E/W) detection in the HDG encoder.

The encoder was checking `headingMagnetic < 0` to determine the direction flag. Since headings are always in [0, 2*PI], this was never true, so westerly variation always produced wrong output:

```
$IIHDG,28.65,-5.73,E,,*37   (before: negative degrees, wrong direction)
$IIHDG,28.65,5.73,W,,*08    (after: correct)
```

The fix checks `magneticVariation < 0` instead, matching the Signal K spec where westerly variation is negative.

Closes #147

## Test plan

- Added test case for westerly (negative) variation, verifying 'W' direction and positive degree value
- Existing easterly variation test continues to pass
- Full test suite passes (49 tests)