### PR TITLE
fix: place magnetic variation in correct HDG fields

### DIFF
--- a/sentences/HDG.js
+++ b/sentences/HDG.js
@@ -1,35 +1,44 @@
 /*
-Heading magnetic:
-$IIHDG,x.x,,,,*hh
- I_Heading magnetic
- */
-// NMEA0183 Encoder HDG   $IIHDG,206.71,,,,*7B
+HDG - Heading, Deviation & Variation
+
+       0   1   2 3   4
+       |   |   | |   |
+$--HDG,x.x,x.x,a,x.x,a*hh<CR><LF>
+
+Field Number:
+0 Magnetic Sensor heading in degrees
+1 Magnetic Deviation, degrees
+2 Magnetic Deviation direction, E = Easterly, W = Westerly
+3 Magnetic Variation degrees
+4 Magnetic Variation direction, E = Easterly, W = Westerly
+*/
 
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {
     sentence: 'HDG',
-    title: 'HDG - Heading magnetic:.',
+    title: 'HDG - Heading, Deviation & Variation',
     keys: ['navigation.headingMagnetic', 'navigation.magneticVariation'],
     defaults: [undefined, ''],
     f: function hdg(headingMagnetic, magneticVariation) {
-      var magneticVariationDir = ''
-      if (magneticVariation != '') {
+      let magneticVariationDeg = ''
+      let magneticVariationDir = ''
+      if (magneticVariation !== '') {
         magneticVariationDir = 'E'
         if (magneticVariation < 0) {
           magneticVariationDir = 'W'
           magneticVariation = Math.abs(magneticVariation)
         }
-        var magneticVariationDeg = nmea.radsToDeg(magneticVariation).toFixed(2)
+        magneticVariationDeg = nmea.radsToDeg(magneticVariation).toFixed(2)
       }
 
       return nmea.toSentence([
         '$IIHDG',
         nmea.radsToDeg(headingMagnetic).toFixed(2),
-        magneticVariationDeg,
-        magneticVariationDir,
         '',
-        ''
+        '',
+        magneticVariationDeg,
+        magneticVariationDir
       ])
     }
   }

--- a/test/HDG.js
+++ b/test/HDG.js
@@ -6,11 +6,15 @@ const { createAppWithPlugin } = require('./testutil')
 // no default, navigation.magneticVariation defaults to ''. This exercises
 // combineStreamsWith with one Property (toProperty(default)) plus one
 // non-defaulted Bus that we then push to.
+//
+// HDG field layout: $--HDG,heading,deviation,devDir,variation,varDir*cs
+// Deviation fields (1-2) are always empty because Signal K's
+// headingMagnetic already has deviation applied.
 describe('HDG', function () {
-  it('emits heading magnetic when only headingMagnetic is pushed', (done) => {
+  it('emits heading with empty deviation and variation when only headingMagnetic is pushed', (done) => {
     const onEmit = (event, value) => {
-      // 0.5 rad ≈ 28.65°, magneticVariation default is empty string,
-      // so the magneticVariationDir branch stays empty: $IIHDG,28.65,,,,*<cs>
+      // 0.5 rad = 28.65 deg; no variation available
+      // Expected: $IIHDG,28.65,,,,*cs
       assert.match(value, /^\$IIHDG,28\.65,,,,\*[0-9A-F]{2}$/)
       done()
     }
@@ -18,14 +22,15 @@ describe('HDG', function () {
     app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
   })
 
-  it('uses pushed magneticVariation when both inputs have values', (done) => {
+  it('places easterly variation in fields 4-5', (done) => {
     const onEmit = (event, value) => {
-      // headingMagnetic = 0.5 rad, magneticVariation = 0.1 rad ≈ 5.73°E.
-      // Push magneticVariation BEFORE headingMagnetic so that the very
-      // first combineWith emission already sees the non-default value.
-      // (debounceImmediate(20) would swallow a second emission if we
-      // pushed headingMagnetic first then magneticVariation.)
-      assert.match(value, /^\$IIHDG,28\.65,5\.73,E,,\*[0-9A-F]{2}$/)
+      // headingMagnetic = 0.5 rad = 28.65 deg
+      // magneticVariation = 0.1 rad = 5.73 deg E
+      // Expected: $IIHDG,28.65,,,5.73,E*cs
+      // Push magneticVariation BEFORE headingMagnetic so the first
+      // combineWith emission already sees the non-default value
+      // (debounceImmediate(20) would swallow a second emission).
+      assert.match(value, /^\$IIHDG,28\.65,,,5\.73,E\*[0-9A-F]{2}$/)
       done()
     }
     const app = createAppWithPlugin(onEmit, 'HDG')
@@ -33,15 +38,38 @@ describe('HDG', function () {
     app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
   })
 
-  it('reports westerly variation with W direction and positive degrees', (done) => {
-    // magneticVariation = -0.1 rad (westerly, negative per Signal K spec)
-    // Expected: direction = 'W', degrees = 5.73 (absolute value)
+  it('places westerly variation in fields 4-5 with W direction', (done) => {
     const onEmit = (event, value) => {
-      assert.match(value, /^\$IIHDG,28\.65,5\.73,W,,\*[0-9A-F]{2}$/)
+      // magneticVariation = -0.1 rad (westerly, negative per Signal K spec)
+      // Expected: direction = 'W', degrees = 5.73 (absolute value)
+      // Expected: $IIHDG,28.65,,,5.73,W*cs
+      assert.match(value, /^\$IIHDG,28\.65,,,5\.73,W\*[0-9A-F]{2}$/)
       done()
     }
     const app = createAppWithPlugin(onEmit, 'HDG')
     app.streambundle.getSelfStream('navigation.magneticVariation').push(-0.1)
+    app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
+  })
+
+  it('handles heading near 360 degrees', (done) => {
+    const onEmit = (event, value) => {
+      // 6.0 rad = 343.77 deg
+      assert.match(value, /^\$IIHDG,343\.77,,,,\*[0-9A-F]{2}$/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'HDG')
+    app.streambundle.getSelfStream('navigation.headingMagnetic').push(6.0)
+  })
+
+  it('handles zero variation as easterly', (done) => {
+    const onEmit = (event, value) => {
+      // magneticVariation = 0 rad; 0 !== '' is true, 0 < 0 is false => 'E'
+      // Expected: $IIHDG,28.65,,,0.00,E*cs
+      assert.match(value, /^\$IIHDG,28\.65,,,0\.00,E\*[0-9A-F]{2}$/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'HDG')
+    app.streambundle.getSelfStream('navigation.magneticVariation').push(0)
     app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
   })
 })


### PR DESCRIPTION
## Summary

- Move magnetic variation from deviation fields (2-3) to the correct variation fields (4-5) per the NMEA 0183 HDG specification
- Deviation fields are left empty since Signal K's `headingMagnetic` already has deviation applied

**Before:** `$IIHDG,180.00,5.73,E,,*xx` (variation in deviation slots)
**After:** `$IIHDG,180.00,,,5.73,E*xx` (variation in correct slots)

Additional improvements:
- Updated header comment with full NMEA 0183 field documentation
- Replaced `var` with `let` for proper scoping
- Replaced loose `!=` with strict `!==`

Fixes #71

## Test plan

- [x] All 55 existing tests pass
- [x] Added tests for easterly variation, westerly variation, heading near 360 degrees, zero variation
- [x] Verified round-trip with `nmea0183-signalk` parser (variation correctly lands in `parts[3]`/`parts[4]`)
- [x] Tested directly in SignalK Docker container via full plugin pipeline
- [x] Prettier check passes