### PR TITLE
fix: emit RMC when COG is unavailable

### DIFF
--- a/sentences/RMC.js
+++ b/sentences/RMC.js
@@ -40,7 +40,7 @@ module.exports = function (app) {
       'navigation.position',
       'navigation.magneticVariation'
     ],
-    defaults: ['', undefined, undefined, undefined, ''],
+    defaults: ['', undefined, null, undefined, ''],
     f: function (datetime8601, sog, cog, position, magneticVariation) {
       const datetime = formatDatetime(datetime8601)
       let magneticVariationDir = 'E'
@@ -55,7 +55,7 @@ module.exports = function (app) {
         toNmeaDegreesLatitude(position.latitude),
         toNmeaDegreesLongitude(position.longitude),
         (sog * 1.94384).toFixed(1),
-        radsToDeg(cog).toFixed(1),
+        cog != null ? radsToDeg(cog).toFixed(1) : '',
         datetime.date,
         typeof magneticVariation === 'number'
           ? radsToDeg(magneticVariation).toFixed(1)

--- a/test/RMC.js
+++ b/test/RMC.js
@@ -99,6 +99,36 @@ describe('RMC', function () {
       .push({ longitude: 5, latitude: 6 })
   })
 
+  // Regression: SignalK/signalk-to-nmea0183#87
+  // Some GPS units omit COG when stationary (SOG=0). The RMC sentence must
+  // still be emitted with an empty COG field so downstream consumers receive
+  // position and time data.
+  it('emits RMC with empty COG when COG is unavailable and SOG=0', (done) => {
+    const onEmit = (event, value) => {
+      assert.equal(value, '$GPRMC,,A,0600.0000,N,00500.0000,E,0.0,,,,E*75')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMC')
+    app.streambundle.getSelfStream('navigation.speedOverGround').push(0)
+    // navigation.courseOverGroundTrue is never pushed
+    app.streambundle
+      .getSelfStream('navigation.position')
+      .push({ longitude: 5, latitude: 6 })
+  })
+
+  it('emits RMC with empty COG when COG is unavailable and SOG>0', (done) => {
+    const onEmit = (event, value) => {
+      assert.equal(value, '$GPRMC,,A,0600.0000,N,00500.0000,E,1.9,,,,E*7D')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMC')
+    app.streambundle.getSelfStream('navigation.speedOverGround').push('1')
+    // navigation.courseOverGroundTrue is never pushed
+    app.streambundle
+      .getSelfStream('navigation.position')
+      .push({ longitude: 5, latitude: 6 })
+  })
+
   it('reports a negative magnetic variation as W', (done) => {
     // Negative radians must flip the hemisphere indicator to W and emit the
     // absolute value of the variation. Covers the magneticVariation < 0 branch


### PR DESCRIPTION
## Summary

Fixes #87.

Some GPS/AIS units (e.g. SITEX N2K) omit `courseOverGroundTrue` when stationary (SOG=0). The COG stream had no default value, so the Bacon.js `combine` never fired and no RMC sentence was produced. Downstream consumers that rely on RMC for position (like wxtoimg) received nothing.

- Give COG a `null` default so the combined stream fires once SOG and position are available
- When COG is `null`, emit an empty track field (valid per NMEA 0183)
- Add regression tests for both SOG=0 and SOG>0 with missing COG

## Test plan

- [x] Existing RMC tests pass (no regressions)
- [x] New test: SOG=0, COG never pushed -> RMC emitted with empty COG field
- [x] New test: SOG>0, COG never pushed -> RMC emitted with empty COG field
- [x] 100% code coverage on RMC.js (statements, branches, functions, lines)
- [x] Prettier passes