### PR TITLE
fix: use waypoint names from nextPoint/previousPoint in RMB fields 4-5

### DIFF
--- a/sentences/RMB.js
+++ b/sentences/RMB.js
@@ -34,16 +34,25 @@ module.exports = function (app) {
       'navigation.course.nextPoint',
       'navigation.course.calcValues.distance',
       'navigation.course.calcValues.bearingTrue',
-      'navigation.course.calcValues.velocityMadeGood'
+      'navigation.course.calcValues.velocityMadeGood',
+      'navigation.course.previousPoint'
     ],
-    f: function (crossTrackError, wp, wpDistance, bearingTrue, vmg) {
+    // nextPoint and previousPoint default to {} so RMB still fires when only
+    // calcValues are available (the common case today). Once signalk-server
+    // populates nextPoint.name / previousPoint.name (see
+    // SignalK/signalk-server#2595, SignalK/specification#676), the waypoint
+    // identifiers will flow through automatically.
+    defaults: [undefined, {}, undefined, undefined, undefined, {}],
+    f: function (crossTrackError, wp, wpDistance, bearingTrue, vmg, prevWp) {
+      var destinationId = (wp && wp.name) || ''
+      var originId = (prevWp && prevWp.name) || ''
       return nmea.toSentence([
         '$IIRMB',
         'A',
         Math.abs(nmea.mToNm(crossTrackError)).toFixed(3),
         crossTrackError < 0 ? 'R' : 'L',
-        '',
-        '',
+        destinationId,
+        originId,
         nmea.toNmeaDegreesLatitude(wp.position?.latitude),
         nmea.toNmeaDegreesLongitude(wp.position?.longitude),
         Math.abs(nmea.mToNm(wpDistance)).toFixed(2),

--- a/test/RMB.js
+++ b/test/RMB.js
@@ -1,0 +1,187 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+describe('RMB', function () {
+  // Real navigation data: route near Zurich, Switzerland.
+  //   crossTrackError = 185.2 m (right of track, steer left)
+  //   nextPoint position = 48.1173 N, 11.5167 E
+  //   distance = 4639.26 m
+  //   bearingTrue = 5.832 rad (334 deg)
+  //   vmg = 2.675 m/s (5.2 kn)
+  const realXte = 185.2
+  const realNextPoint = {
+    position: { latitude: 48.1173, longitude: 11.5167 }
+  }
+  const realDistance = 4639.26
+  const realBearingTrue = 5.832
+  const realVmg = 2.675
+
+  function pushRmbStreams(app, overrides) {
+    // Push point objects before calcValues so they are already present when
+    // the combined stream fires. The point keys have defaults of {}, so
+    // pushing calcValues alone would emit immediately with those defaults.
+    if ('nextPoint' in overrides) {
+      app.streambundle
+        .getSelfStream('navigation.course.nextPoint')
+        .push(overrides.nextPoint)
+    }
+    if ('previousPoint' in overrides) {
+      app.streambundle
+        .getSelfStream('navigation.course.previousPoint')
+        .push(overrides.previousPoint)
+    }
+    const calcValues = {
+      'navigation.course.calcValues.crossTrackError':
+        overrides.crossTrackError ?? realXte,
+      'navigation.course.nextPoint': overrides.nextPoint ?? realNextPoint,
+      'navigation.course.calcValues.distance':
+        overrides.distance ?? realDistance,
+      'navigation.course.calcValues.bearingTrue':
+        overrides.bearingTrue ?? realBearingTrue,
+      'navigation.course.calcValues.velocityMadeGood': overrides.vmg ?? realVmg
+    }
+    for (const [path, value] of Object.entries(calcValues)) {
+      app.streambundle.getSelfStream(path).push(value)
+    }
+  }
+
+  // The toNmeaDegrees* helpers embed a comma (e.g. "4807.0380,N"), so the
+  // final sentence has more comma-separated fields than array elements.
+  // Parse by splitting on comma and mapping to NMEA field numbers.
+  function parseRmb(sentence) {
+    const body = sentence.split('*')[0]
+    const parts = body.split(',')
+    return {
+      talker: parts[0],
+      status: parts[1],
+      xteMagnitude: parts[2],
+      steerDirection: parts[3],
+      destinationId: parts[4],
+      originId: parts[5],
+      latitude: parts[6] + ',' + parts[7],
+      longitude: parts[8] + ',' + parts[9],
+      range: parts[10],
+      bearing: parts[11],
+      vmg: parts[12],
+      arrivalStatus: parts[13],
+      faaMode: parts[14]
+    }
+  }
+
+  it('emits a valid RMB sentence with real navigation data', (done) => {
+    const onEmit = (event, value) => {
+      const fields = parseRmb(value)
+      assert.equal(fields.talker, '$IIRMB')
+      assert.equal(fields.status, 'A')
+      assert.equal(fields.faaMode, 'A')
+      assert.equal(fields.bearing, '334')
+      assert.equal(fields.vmg, '5.20')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMB')
+    pushRmbStreams(app, {})
+  })
+
+  it('uses waypoint names in fields 4 and 5 when available', (done) => {
+    const onEmit = (event, value) => {
+      const fields = parseRmb(value)
+      assert.equal(
+        fields.destinationId,
+        'DEST',
+        'field 4 should contain the destination waypoint name'
+      )
+      assert.equal(
+        fields.originId,
+        'START',
+        'field 5 should contain the origin waypoint name'
+      )
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMB')
+    pushRmbStreams(app, {
+      nextPoint: {
+        position: { latitude: 48.1173, longitude: 11.5167 },
+        type: 'Waypoint',
+        name: 'DEST'
+      },
+      previousPoint: {
+        position: { latitude: 47.3769, longitude: 8.5417 },
+        type: 'Waypoint',
+        name: 'START'
+      }
+    })
+  })
+
+  it('uses empty fields when waypoint objects have no name', (done) => {
+    const onEmit = (event, value) => {
+      const fields = parseRmb(value)
+      assert.equal(
+        fields.destinationId,
+        '',
+        'field 4 should be empty when no waypoint name is available'
+      )
+      assert.equal(
+        fields.originId,
+        '',
+        'field 5 should be empty when no waypoint name is available'
+      )
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMB')
+    pushRmbStreams(app, {
+      nextPoint: {
+        position: { latitude: 48.1173, longitude: 11.5167 },
+        type: 'RoutePoint'
+      },
+      previousPoint: {
+        position: { latitude: 47.3769, longitude: 8.5417 },
+        type: 'RoutePoint'
+      }
+    })
+  })
+
+  it('computes correct XTE and steer direction', (done) => {
+    // XTE = 185.2 m positive means vessel is right of track, steer Left.
+    // Magnitude in NM: 185.2 * 0.000539957 = 0.100 NM
+    const onEmit = (event, value) => {
+      const fields = parseRmb(value)
+      assert.equal(fields.steerDirection, 'L', 'positive XTE = steer left')
+      assert.equal(fields.xteMagnitude, '0.100')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMB')
+    pushRmbStreams(app, {})
+  })
+
+  it('computes range in nautical miles', (done) => {
+    // distance = 4639.26 m, mToNm = v * 0.000539957
+    // 4639.26 * 0.000539957 = 2.505 -> toFixed(2) = "2.51"
+    const onEmit = (event, value) => {
+      const fields = parseRmb(value)
+      assert.equal(fields.range, '2.51')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMB')
+    pushRmbStreams(app, {})
+  })
+
+  it('subscribes to previousPoint for origin waypoint metadata', () => {
+    const app = {
+      streambundle: { getSelfStream: () => ({ toProperty: () => ({}) }) },
+      emit: () => {},
+      debug: () => {}
+    }
+    const rmb = require('../sentences/RMB')(app)
+    assert.ok(
+      rmb.keys.includes('navigation.course.previousPoint'),
+      'RMB keys should include navigation.course.previousPoint, got: ' +
+        JSON.stringify(rmb.keys)
+    )
+    assert.ok(
+      rmb.keys.includes('navigation.course.nextPoint'),
+      'RMB keys should include navigation.course.nextPoint, got: ' +
+        JSON.stringify(rmb.keys)
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- RMB fields 4 (TO Waypoint ID) and 5 (FROM Waypoint ID) were hardcoded as empty strings. Now reads `nextPoint.name` and `previousPoint.name` when available, falling back to empty fields.
- Subscribes to `navigation.course.previousPoint` with a default of `{}` so RMB still fires when only calcValues are present.
- Adds 6 tests for RMB covering waypoint name population, empty fallback, XTE, range, and key subscriptions.

## Upstream dependency

Same as #155 (APB fix): the Signal K server does not yet populate `nextPoint.name` / `previousPoint.name`. Spec and server changes have been filed:
- SignalK/specification#676
- SignalK/signalk-server#2595

Once those land, both waypoint identifiers flow through automatically. Until then, fields 4-5 are empty (valid per NMEA spec) instead of hardcoded placeholders.

## Parser side

The parser-side fix (parsing waypoint IDs from incoming RMB sentences into `courseRhumbline.nextPoint.ID` / `previousPoint.ID`) is in SignalK/nmea0183-signalk#297.

## Test plan

- [x] All 63 tests pass (6 new RMB tests + 57 existing)
- [x] Prettier check passes

Fixes #150