### PR TITLE
chore: clean up dead imports, copy-paste names, and stale markers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,3 @@
-const {
-  toSentence,
-  computeChecksum,
-  toHexString,
-  radsToDeg,
-  padd,
-  toNmeaDegrees
-} = require('./nmea')
 const path = require('path')
 const fs = require('fs')
 

--- a/sentences/DBK.js
+++ b/sentences/DBK.js
@@ -5,7 +5,7 @@ module.exports = function (app) {
     sentence: 'DBK',
     title: 'DBK - Depth Below Keel',
     keys: ['environment.depth.belowKeel'],
-    f: function mwv(depth) {
+    f: function dbk(depth) {
       var feet = depth * 3.28084
       var fathoms = depth * 0.546807
       return nmea.toSentence([

--- a/sentences/DBS.js
+++ b/sentences/DBS.js
@@ -1,11 +1,10 @@
-// to verify
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {
     sentence: 'DBS',
     title: 'DBS - Depth Below Surface',
     keys: ['environment.depth.belowSurface'],
-    f: function mwv(depth) {
+    f: function dbs(depth) {
       var feet = depth * 3.28084
       var fathoms = depth * 0.546807
       return nmea.toSentence([

--- a/sentences/DBT.js
+++ b/sentences/DBT.js
@@ -5,7 +5,7 @@ module.exports = function (app) {
     sentence: 'DBT',
     title: 'DBT - Depth Below Transducer',
     keys: ['environment.depth.belowTransducer'],
-    f: function mwv(depth) {
+    f: function dbt(depth) {
       var feet = depth * 3.28084
       var fathoms = depth * 0.546807
       return nmea.toSentence([

--- a/sentences/PNKEP02.js
+++ b/sentences/PNKEP02.js
@@ -2,7 +2,6 @@
 $PNKEP,02,x.x*hh<CR><LF>
            \ Course (COG) on other tack from 0 to 359°
 */
-// to verify
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {

--- a/sentences/PNKEP03.js
+++ b/sentences/PNKEP03.js
@@ -6,8 +6,6 @@ $PNKEP,03,x.x,x.x,x.x*hh
                   | Polar efficiency in %
 
 */
-
-// to verify
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {

--- a/sentences/PNKEP99.js
+++ b/sentences/PNKEP99.js
@@ -1,6 +1,3 @@
-/** test */
-
-// to verify
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {

--- a/sentences/RMC.js
+++ b/sentences/RMC.js
@@ -27,6 +27,7 @@ const {
   toNmeaDegreesLatitude,
   toNmeaDegreesLongitude,
   radsToDeg,
+  msToKnots,
   formatDatetime
 } = require('../nmea.js')
 module.exports = function (app) {
@@ -54,7 +55,7 @@ module.exports = function (app) {
         'A',
         toNmeaDegreesLatitude(position.latitude),
         toNmeaDegreesLongitude(position.longitude),
-        (sog * 1.94384).toFixed(1),
+        msToKnots(sog).toFixed(1),
         cog != null ? radsToDeg(cog).toFixed(1) : '',
         datetime.date,
         typeof magneticVariation === 'number'

--- a/sentences/ROT.js
+++ b/sentences/ROT.js
@@ -1,5 +1,3 @@
-// to verify
-
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {

--- a/sentences/XTE-GC.js
+++ b/sentences/XTE-GC.js
@@ -3,7 +3,6 @@ Cross-track error:
 $IIXTE,A,A,x.x,a,N,A*hh
  I_Cross-track error in miles, L= left, R= right
  */
-// to verify
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {

--- a/sentences/XTE.js
+++ b/sentences/XTE.js
@@ -3,7 +3,6 @@ Cross-track error:
 $IIXTE,A,A,x.x,a,N,A*hh
  I_Cross-track error in miles, L= left, R= right
  */
-// to verify
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {


### PR DESCRIPTION
## Summary
- Remove unused `require('./nmea')` destructuring in index.js (none of the imported names -- `toSentence`, `computeChecksum`, `toHexString`, `radsToDeg`, `padd`, `toNmeaDegrees` -- are referenced in that file; sentence generators require nmea.js directly)
- Rename copy-pasted `mwv` function names in DBK, DBS, DBT to match their actual sentence type
- Remove stale `// to verify` comments from DBS, PNKEP02, PNKEP03, PNKEP99, ROT, XTE, XTE-GC
- Use `msToKnots()` in RMC instead of inline magic constant `1.94384`, consistent with all other speed conversions

## Test plan
- [x] `npm test` -- all 69 tests pass
- [x] `npx prettier --check .` -- no formatting issues
- [x] No behavioral changes, pure cleanup