### PR TITLE
fix: normalize heading/direction angles to [0, 360) in HDMC and MWD

### DIFF
--- a/sentences/HDMC.js
+++ b/sentences/HDMC.js
@@ -7,6 +7,8 @@ module.exports = function (app) {
     keys: ['navigation.headingTrue', 'navigation.magneticVariation'],
     f: function (headingTrue, magneticVariation) {
       var heading = headingTrue - magneticVariation
+      if (heading > 2 * Math.PI) heading -= 2 * Math.PI
+      else if (heading < 0) heading += 2 * Math.PI
       return nmea.toSentence([
         '$IIHDM',
         nmea.radsToDeg(heading).toFixed(1),

--- a/sentences/MWD.js
+++ b/sentences/MWD.js
@@ -21,12 +21,12 @@ module.exports = function (app) {
       'environment.wind.speedTrue'
     ],
     f: function (directionTrue, magneticVariation, speedTrue) {
-      var directionMagnetic = nmea.fixAngle(directionTrue - magneticVariation)
+      var directionMagnetic = directionTrue - magneticVariation
       return nmea.toSentence([
         '$IIMWD',
-        nmea.radsToDeg(directionTrue).toFixed(2),
+        nmea.radsToPositiveDeg(directionTrue).toFixed(2),
         'T',
-        nmea.radsToDeg(directionMagnetic).toFixed(2),
+        nmea.radsToPositiveDeg(directionMagnetic).toFixed(2),
         'M',
         nmea.msToKnots(speedTrue).toFixed(2),
         'N',

--- a/test/HDMC.js
+++ b/test/HDMC.js
@@ -19,4 +19,36 @@ describe('HDMC', function () {
       .push((10 * Math.PI) / 180)
     app.streambundle.getSelfStream('navigation.headingTrue').push(Math.PI)
   })
+
+  it('wraps into [0, 360) when variation exceeds true heading', (done) => {
+    // headingTrue = 5 deg, variation = 10 deg easterly
+    // headingMagnetic = 5 - 10 = -5 deg -> must wrap to 355 deg
+    const onEmit = (event, value) => {
+      assert.match(value, /^\$IIHDM,355\.0,M\*[0-9A-F]{2}$/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'HDMC')
+    app.streambundle
+      .getSelfStream('navigation.magneticVariation')
+      .push((10 * Math.PI) / 180)
+    app.streambundle
+      .getSelfStream('navigation.headingTrue')
+      .push((5 * Math.PI) / 180)
+  })
+
+  it('wraps into [0, 360) when westerly variation pushes heading above 360', (done) => {
+    // headingTrue = 355 deg, variation = -10 deg (westerly)
+    // headingMagnetic = 355 - (-10) = 365 deg -> must wrap to 5 deg
+    const onEmit = (event, value) => {
+      assert.match(value, /^\$IIHDM,5\.0,M\*[0-9A-F]{2}$/)
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'HDMC')
+    app.streambundle
+      .getSelfStream('navigation.magneticVariation')
+      .push((-10 * Math.PI) / 180)
+    app.streambundle
+      .getSelfStream('navigation.headingTrue')
+      .push((355 * Math.PI) / 180)
+  })
 })

--- a/test/MWD.js
+++ b/test/MWD.js
@@ -1,0 +1,65 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+// Parse the comma-separated body of an NMEA sentence, stripping the checksum.
+function parseSentence(sentence) {
+  const star = sentence.indexOf('*')
+  const body = star >= 0 ? sentence.substring(0, star) : sentence
+  return body.split(',')
+}
+
+function pushMWD(app, directionTrueRad, variationRad, speedTrueMs) {
+  app.streambundle
+    .getSelfStream('environment.wind.directionTrue')
+    .push(directionTrueRad)
+  app.streambundle
+    .getSelfStream('navigation.magneticVariation')
+    .push(variationRad)
+  app.streambundle.getSelfStream('environment.wind.speedTrue').push(speedTrueMs)
+}
+
+describe('MWD', function () {
+  it('emits true and magnetic direction with speed in knots and m/s', (done) => {
+    // directionTrue = 90 deg, variation = 10 deg east
+    // directionMagnetic = 90 - 10 = 80 deg
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[0], '$IIMWD')
+      assert.equal(parts[1], '90.00')
+      assert.equal(parts[2], 'T')
+      assert.equal(parts[3], '80.00')
+      assert.equal(parts[4], 'M')
+      assert.equal(parts[6], 'N')
+      assert.equal(parts[8], 'M')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'MWD')
+    pushMWD(app, Math.PI / 2, (10 * Math.PI) / 180, 5)
+  })
+
+  it('produces positive magnetic direction when variation exceeds true direction', (done) => {
+    // directionTrue = 5 deg, variation = 10 deg east
+    // directionMagnetic = 5 - 10 = -5 deg -> must be 355 deg (not -5)
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[1], '5.00')
+      assert.equal(parts[3], '355.00')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'MWD')
+    pushMWD(app, (5 * Math.PI) / 180, (10 * Math.PI) / 180, 5)
+  })
+
+  it('produces positive true direction for negative radian input', (done) => {
+    // directionTrue = -10 deg (equivalent to 350 deg), variation = 0
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[1], '350.00')
+      assert.equal(parts[3], '350.00')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'MWD')
+    pushMWD(app, (-10 * Math.PI) / 180, 0, 5)
+  })
+})


### PR DESCRIPTION
## Summary
- **HDMC**: Add angle wrapping to [0, 2*PI) after computing `headingTrue - magneticVariation`. Without this, a true heading of 5 deg with 10 deg east variation produced -5 deg in the NMEA sentence instead of 355 deg. Same wrap pattern that HDTC already uses.
- **MWD**: Replace `radsToDeg()` with `radsToPositiveDeg()` for both true and magnetic wind direction fields. NMEA MWD requires 0-359; `radsToDeg()` can produce negative values. Also drops the intermediate `fixAngle()` call since `radsToPositiveDeg` already normalizes.

## Test plan
- [x] `npm test` -- all 74 tests pass (5 new)
- [x] New tests for HDMC: wrap-negative and wrap-above-360 edge cases
- [x] New test file for MWD: positive output for negative radian input and for variation > direction