### PR TITLE
fix: omit RMC variation direction when variation is unknown

### DIFF
--- a/sentences/RMC.js
+++ b/sentences/RMC.js
@@ -43,10 +43,15 @@ module.exports = function (app) {
     defaults: ['', undefined, null, undefined, ''],
     f: function (datetime8601, sog, cog, position, magneticVariation) {
       const datetime = formatDatetime(datetime8601)
-      let magneticVariationDir = 'E'
-      if (magneticVariation < 0) {
-        magneticVariationDir = 'W'
-        magneticVariation = magneticVariation * -1
+      let magneticVariationDeg = ''
+      let magneticVariationDir = ''
+      if (typeof magneticVariation === 'number') {
+        magneticVariationDir = 'E'
+        if (magneticVariation < 0) {
+          magneticVariationDir = 'W'
+          magneticVariation = -magneticVariation
+        }
+        magneticVariationDeg = radsToDeg(magneticVariation).toFixed(1)
       }
       return toSentence([
         '$GPRMC',
@@ -57,9 +62,7 @@ module.exports = function (app) {
         (sog * 1.94384).toFixed(1),
         cog != null ? radsToDeg(cog).toFixed(1) : '',
         datetime.date,
-        typeof magneticVariation === 'number'
-          ? radsToDeg(magneticVariation).toFixed(1)
-          : magneticVariation,
+        magneticVariationDeg,
         magneticVariationDir
       ])
     }

--- a/test/RMC.js
+++ b/test/RMC.js
@@ -5,7 +5,7 @@ const { createAppWithPlugin } = require('./testutil')
 describe('RMC', function () {
   it('works without datetime & magneticVariation', (done) => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$GPRMC,,A,0600.0000,N,00500.0000,E,1.9,114.6,,,E*51')
+      assert.equal(value, '$GPRMC,,A,0600.0000,N,00500.0000,E,1.9,114.6,,,*14')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'RMC')
@@ -35,7 +35,7 @@ describe('RMC', function () {
 
   it('ignores a too large longitude', (done) => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$GPRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,,E*4C')
+      assert.equal(value, '$GPRMC,,A,3749.6038,N,12225.2480,W,1.9,114.6,,,*09')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'RMC')
@@ -58,7 +58,7 @@ describe('RMC', function () {
     const onEmit = (event, value) => {
       assert.equal(
         value,
-        '$GPRMC,200152.00,A,5943.2980,N,02444.2043,E,13.0,194.3,051215,,E*46'
+        '$GPRMC,200152.00,A,5943.2980,N,02444.2043,E,13.0,194.3,051215,,*03'
       )
       done()
     }
@@ -105,7 +105,7 @@ describe('RMC', function () {
   // position and time data.
   it('emits RMC with empty COG when COG is unavailable and SOG=0', (done) => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$GPRMC,,A,0600.0000,N,00500.0000,E,0.0,,,,E*75')
+      assert.equal(value, '$GPRMC,,A,0600.0000,N,00500.0000,E,0.0,,,,*30')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'RMC')
@@ -118,7 +118,7 @@ describe('RMC', function () {
 
   it('emits RMC with empty COG when COG is unavailable and SOG>0', (done) => {
     const onEmit = (event, value) => {
-      assert.equal(value, '$GPRMC,,A,0600.0000,N,00500.0000,E,1.9,,,,E*7D')
+      assert.equal(value, '$GPRMC,,A,0600.0000,N,00500.0000,E,1.9,,,,*38')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'RMC')


### PR DESCRIPTION
## Summary
- When `magneticVariation` defaults to `''` (no data pushed), the RMC encoder unconditionally set the direction field to `'E'`, producing `,,E` in the sentence. Per NMEA 0183, both the variation value and direction fields should be empty when variation is unavailable.
- Guard the direction logic behind a `typeof === 'number'` check so both fields stay empty when no variation data exists.
- Same pattern already used in HDG.js for the variation/direction pair.

**Before:** `$GPRMC,,A,0600.0000,N,00500.0000,E,1.9,114.6,,,E*51`
**After:** `$GPRMC,,A,0600.0000,N,00500.0000,E,1.9,114.6,,,*14`

## Test plan
- [x] `npm test` -- all 69 tests pass
- [x] Updated 5 existing test expectations to match corrected output
- [x] Existing tests for easterly and westerly variation still pass unchanged