### PR TITLE
fix: use True bearing consistently for all APB bearing pairs

### DIFF
--- a/sentences/APB.js
+++ b/sentences/APB.js
@@ -31,7 +31,7 @@
       14. M = Magnetic, T = True
       15. Checksum
 
-      Example: $GPAPB,A,A,0.10,R,N,V,V,011,M,DEST,011,M,011,M*82
+      Example: $GPAPB,A,A,0.10,R,N,V,V,011,T,DEST,011,T,011,T*82
     */
 const nmea = require('../nmea.js')
 module.exports = function (app) {
@@ -42,15 +42,14 @@ module.exports = function (app) {
       'navigation.course.calcValues.crossTrackError',
       'navigation.course.calcValues.bearingTrackTrue',
       'navigation.course.calcValues.bearingTrue',
-      'navigation.course.calcValues.bearingMagnetic',
       'navigation.course.nextPoint'
     ],
     // nextPoint defaults to {} so APB still fires when only calcValues are
     // available (the common case today). Once signalk-server populates
     // nextPoint.name (see SignalK/signalk-server#2595, SignalK/specification#676),
     // the waypoint identifier will flow through automatically.
-    defaults: [undefined, undefined, undefined, undefined, {}],
-    f: function (xte, originToDest, bearingTrue, bearingMagnetic, nextPoint) {
+    defaults: [undefined, undefined, undefined, {}],
+    f: function (xte, originToDest, bearingTrue, nextPoint) {
       var waypointId = (nextPoint && nextPoint.name) || ''
       return nmea.toSentence([
         '$IIAPB',
@@ -66,8 +65,8 @@ module.exports = function (app) {
         waypointId,
         nmea.radsToPositiveDeg(bearingTrue).toFixed(0),
         'T',
-        nmea.radsToPositiveDeg(bearingMagnetic).toFixed(0),
-        'M'
+        nmea.radsToPositiveDeg(bearingTrue).toFixed(0),
+        'T'
       ])
     }
   }

--- a/test/APB.js
+++ b/test/APB.js
@@ -7,11 +7,9 @@ describe('APB', function () {
   //   crossTrackError = -39.84 m (left of track)
   //   bearingTrackTrue = 2.1503 rad (123 deg)
   //   bearingTrue = 2.1962 rad (126 deg)
-  //   bearingMagnetic = 2.0400 rad (117 deg)
   const realXte = -39.84
   const realBearingTrackTrue = 2.1503
   const realBearingTrue = 2.1962
-  const realBearingMagnetic = 2.04
 
   function pushApbStreams(app, overrides) {
     // Push nextPoint before calcValues so it is already present when the
@@ -29,9 +27,7 @@ describe('APB', function () {
       'navigation.course.calcValues.bearingTrackTrue':
         overrides.bearingTrackTrue ?? realBearingTrackTrue,
       'navigation.course.calcValues.bearingTrue':
-        overrides.bearingTrue ?? realBearingTrue,
-      'navigation.course.calcValues.bearingMagnetic':
-        overrides.bearingMagnetic ?? realBearingMagnetic
+        overrides.bearingTrue ?? realBearingTrue
     }
     for (const [path, value] of Object.entries(calcValues)) {
       app.streambundle.getSelfStream(path).push(value)
@@ -152,15 +148,57 @@ describe('APB', function () {
   it('computes bearings in degrees from radians', (done) => {
     // bearingTrackTrue = 2.1503 rad = 123 deg
     // bearingTrue = 2.1962 rad = 126 deg
-    // bearingMagnetic = 2.0400 rad = 117 deg
+    // All three bearing pairs use True (fields 9, 12, 14 = 'T').
+    // Heading to steer (field 13) equals bearingTrue, not bearingMagnetic.
     const onEmit = (event, value) => {
       const fields = parseApb(value)
       assert.equal(fields.bearingOriginToDest, '123')
       assert.equal(fields.bearingPosToDest, '126')
-      assert.equal(fields.headingToSteer, '117')
+      assert.equal(fields.headingToSteer, '126')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'APB')
     pushApbStreams(app, {})
+  })
+
+  it('uses True reference for all three bearing pairs', (done) => {
+    // NMEA APB carries three bearing pairs (fields 8-9, 11-12, 13-14).
+    // All must use the same reference system. This plugin uses True for all
+    // three, which is correct for autopilots with a true heading source and
+    // matches the convention used by RMB in this repo.
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(fields.bearingOriginToDestRef, 'T', 'field 9')
+      assert.equal(fields.bearingPosToDestRef, 'T', 'field 12')
+      assert.equal(fields.headingToSteerRef, 'T', 'field 14')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB')
+    pushApbStreams(app, {})
+  })
+
+  it('steers Left when XTE is positive (vessel right of track)', (done) => {
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(fields.steerDirection, 'L', 'positive XTE = steer left')
+      assert.equal(fields.xteMagnitude, '0.054')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB')
+    pushApbStreams(app, { crossTrackError: 100 })
+  })
+
+  it('does not subscribe to bearingMagnetic', () => {
+    const app = {
+      streambundle: { getSelfStream: () => ({ toProperty: () => ({}) }) },
+      emit: () => {},
+      debug: () => {}
+    }
+    const apb = require('../sentences/APB')(app)
+    assert.ok(
+      !apb.keys.includes('navigation.course.calcValues.bearingMagnetic'),
+      'APB should not subscribe to bearingMagnetic, got: ' +
+        JSON.stringify(apb.keys)
+    )
   })
 })


### PR DESCRIPTION
## Summary

Fixes #144.

- Fields 13-14 (heading to steer) used `bearingMagnetic` + `M` while fields 8-9 and 11-12 used True references. This mixing caused autopilots like pypilot to reject the APB sentence (see #129).
- All three bearing pairs now use `bearingTrue` + `T`, matching the convention used by RMB in this repo and standard practice across chart plotters (TimeZero, OpenCPN).
- Removed the unused `bearingMagnetic` subscription, reducing the number of combined streams by one.

## Test plan

- [x] Updated existing bearing test to expect True values in fields 13-14
- [x] Added test verifying all three reference indicators are `T`
- [x] Added test for positive XTE (steer Left), covering previously uncovered branch
- [x] Added test confirming `bearingMagnetic` is no longer in `keys`
- [x] APB.js now at 100% coverage across statements, branches, functions, and lines
- [x] All 72 tests pass, prettier check passes
- [x] Integration-tested against signalk-server v2.24.0 in Docker (plugin loaded, delta injected, APB output verified)