### PR TITLE
fix: normalize VTG course angles, guard RMB against missing waypoint position

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,6 @@ module.exports = function (app) {
   }
 
   plugin.start = function (options) {
-    const selfContext = 'vessels.' + app.selfId
-    const selfMatcher = (delta) =>
-      delta.context && delta.context === selfContext
-
     function mapToNmea(encoder, throttle) {
       const selfStreams = encoder.keys.map((key, index) => {
         let stream = app.streambundle.getSelfStream(key)

--- a/nmea.js
+++ b/nmea.js
@@ -135,7 +135,9 @@ function fixAngle(d) {
 }
 
 function toPositiveRadians(d) {
-  return d < 0 ? d + 2 * Math.PI : d
+  let result = d % (2 * Math.PI)
+  if (result < 0) result += 2 * Math.PI
+  return result
 }
 
 function radsToPositiveDeg(r) {

--- a/sentences/HDG.js
+++ b/sentences/HDG.js
@@ -34,7 +34,7 @@ module.exports = function (app) {
 
       return nmea.toSentence([
         '$IIHDG',
-        nmea.radsToDeg(headingMagnetic).toFixed(2),
+        nmea.radsToPositiveDeg(headingMagnetic).toFixed(2),
         '',
         '',
         magneticVariationDeg,

--- a/sentences/HDM.js
+++ b/sentences/HDM.js
@@ -8,7 +8,7 @@ module.exports = function (app) {
     f: function (heading) {
       return nmea.toSentence([
         '$IIHDM',
-        nmea.radsToDeg(heading).toFixed(1),
+        nmea.radsToPositiveDeg(heading).toFixed(1),
         'M'
       ])
     }

--- a/sentences/HDMC.js
+++ b/sentences/HDMC.js
@@ -7,11 +7,9 @@ module.exports = function (app) {
     keys: ['navigation.headingTrue', 'navigation.magneticVariation'],
     f: function (headingTrue, magneticVariation) {
       var heading = headingTrue - magneticVariation
-      if (heading > 2 * Math.PI) heading -= 2 * Math.PI
-      else if (heading < 0) heading += 2 * Math.PI
       return nmea.toSentence([
         '$IIHDM',
-        nmea.radsToDeg(heading).toFixed(1),
+        nmea.radsToPositiveDeg(heading).toFixed(1),
         'M'
       ])
     }

--- a/sentences/HDT.js
+++ b/sentences/HDT.js
@@ -8,7 +8,7 @@ module.exports = function (app) {
     f: function (heading) {
       return nmea.toSentence([
         '$IIHDT',
-        nmea.radsToDeg(heading).toFixed(1),
+        nmea.radsToPositiveDeg(heading).toFixed(1),
         'T'
       ])
     }

--- a/sentences/HDTC.js
+++ b/sentences/HDTC.js
@@ -7,11 +7,9 @@ module.exports = function (app) {
     keys: ['navigation.headingMagnetic', 'navigation.magneticVariation'],
     f: function (headingMagnetic, magneticVariation) {
       var heading = headingMagnetic + magneticVariation
-      if (heading > 2 * Math.PI) heading -= 2 * Math.PI
-      else if (heading < 0) heading += 2 * Math.PI
       return nmea.toSentence([
         '$IIHDT',
-        nmea.radsToDeg(heading).toFixed(1),
+        nmea.radsToPositiveDeg(heading).toFixed(1),
         'T'
       ])
     }

--- a/sentences/MMB.js
+++ b/sentences/MMB.js
@@ -12,7 +12,6 @@ module.exports = function (app) {
     title: 'MMB - Environment outside pressure',
     keys: ['environment.outside.pressure'],
     f: function (pressure) {
-      // console.log("Got MMB--------------------------");
       return nmea.toSentence([
         '$IIMMB',
         (pressure / 3386.39).toFixed(4),

--- a/sentences/MTA.js
+++ b/sentences/MTA.js
@@ -12,7 +12,6 @@ module.exports = function (app) {
     title: 'MTA - Air temperature.',
     keys: ['environment.outside.temperature'],
     f: function (temperature) {
-      // console.log("Got MTA--------------------------");
       var celcius = temperature - 273.15
       return nmea.toSentence(['$IIMTA', celcius.toFixed(2), 'C'])
     }

--- a/sentences/MWD.js
+++ b/sentences/MWD.js
@@ -21,7 +21,7 @@ module.exports = function (app) {
       'environment.wind.speedTrue'
     ],
     f: function (directionTrue, magneticVariation, speedTrue) {
-      var directionMagnetic = directionTrue - magneticVariation
+      var directionMagnetic = nmea.fixAngle(directionTrue - magneticVariation)
       return nmea.toSentence([
         '$IIMWD',
         nmea.radsToPositiveDeg(directionTrue).toFixed(2),

--- a/sentences/MWVR.js
+++ b/sentences/MWVR.js
@@ -22,7 +22,7 @@ const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {
     sentence: 'MWV',
-    title: 'MWV - Aparent Wind heading and speed',
+    title: 'MWV - Apparent Wind heading and speed',
     keys: ['environment.wind.angleApparent', 'environment.wind.speedApparent'],
     f: function (angle, speed) {
       return nmea.toSentence([

--- a/sentences/PNKEP01.js
+++ b/sentences/PNKEP01.js
@@ -12,7 +12,6 @@ module.exports = function (app) {
     title: 'PNKEP,01 - Target Polar speed',
     keys: ['performance.polarSpeed'],
     f: function (polarSpeed) {
-      // console.log("Got Polar speed --------------------------------------------------");
       return nmea.toSentence([
         '$PNKEP',
         '01',

--- a/sentences/PNKEP02.js
+++ b/sentences/PNKEP02.js
@@ -8,12 +8,10 @@ module.exports = function (app) {
     title: 'PNKEP,02 - Course (COG) on other tack from 0 to 359°',
     keys: ['performance.tackMagnetic'],
     f: function (tackMagnetic) {
-      // console.log("Got tackMagnetic --------------------------------------------------");
-
       return nmea.toSentence([
         '$PNKEP',
         '02',
-        nmea.radsToDeg(tackMagnetic).toFixed(2)
+        nmea.radsToPositiveDeg(tackMagnetic).toFixed(2)
       ])
     }
   }

--- a/sentences/PNKEP03.js
+++ b/sentences/PNKEP03.js
@@ -19,7 +19,7 @@ module.exports = function (app) {
       return nmea.toSentence([
         '$PNKEP',
         '03',
-        nmea.radsToDeg(targetAngle).toFixed(2),
+        nmea.radsToPositiveDeg(targetAngle).toFixed(2),
         (polarVelocityMadeGoodRatio * 100.0).toFixed(2),
         (polarSpeedRatio * 100.0).toFixed(2)
       ])

--- a/sentences/PNKEP99.js
+++ b/sentences/PNKEP99.js
@@ -20,7 +20,6 @@ module.exports = function (app) {
       polarSpeed,
       polarSpeedRatio
     ) {
-      // console.log("Got Polar speed --------------------------------------------------");
       return nmea.toSentence([
         '$PNKEP',
         '99',

--- a/sentences/PSILCD1.js
+++ b/sentences/PSILCD1.js
@@ -20,7 +20,7 @@ module.exports = function (app) {
       return nmea.toSentence([
         '$PSILCD1',
         nmea.msToKnots(polarSpeed).toFixed(2),
-        nmea.radsToDeg(targetAngle).toFixed(2)
+        nmea.radsToPositiveDeg(targetAngle).toFixed(2)
       ])
     }
   }

--- a/sentences/RMB.js
+++ b/sentences/RMB.js
@@ -46,6 +46,11 @@ module.exports = function (app) {
     f: function (crossTrackError, wp, wpDistance, bearingTrue, vmg, prevWp) {
       var destinationId = (wp && wp.name) || ''
       var originId = (prevWp && prevWp.name) || ''
+      var wpLat = wp.position?.latitude
+      var wpLon = wp.position?.longitude
+      if (typeof wpLat !== 'number' || typeof wpLon !== 'number') {
+        return
+      }
       return nmea.toSentence([
         '$IIRMB',
         'A',
@@ -53,8 +58,8 @@ module.exports = function (app) {
         crossTrackError < 0 ? 'R' : 'L',
         destinationId,
         originId,
-        nmea.toNmeaDegreesLatitude(wp.position?.latitude),
-        nmea.toNmeaDegreesLongitude(wp.position?.longitude),
+        nmea.toNmeaDegreesLatitude(wpLat),
+        nmea.toNmeaDegreesLongitude(wpLon),
         Math.abs(nmea.mToNm(wpDistance)).toFixed(2),
         nmea.radsToPositiveDeg(bearingTrue).toFixed(0),
         nmea.msToKnots(vmg).toFixed(2),

--- a/sentences/RMC.js
+++ b/sentences/RMC.js
@@ -27,6 +27,7 @@ const {
   toNmeaDegreesLatitude,
   toNmeaDegreesLongitude,
   radsToDeg,
+  radsToPositiveDeg,
   msToKnots,
   formatDatetime
 } = require('../nmea.js')
@@ -61,7 +62,7 @@ module.exports = function (app) {
         toNmeaDegreesLatitude(position.latitude),
         toNmeaDegreesLongitude(position.longitude),
         msToKnots(sog).toFixed(1),
-        cog != null ? radsToDeg(cog).toFixed(1) : '',
+        cog != null ? radsToPositiveDeg(cog).toFixed(1) : '',
         datetime.date,
         magneticVariationDeg,
         magneticVariationDir

--- a/sentences/VHW.js
+++ b/sentences/VHW.js
@@ -20,17 +20,11 @@ module.exports = function (app) {
     ],
     f: function vhw(headingTrue, magneticVariation, speedThroughWater) {
       var headingMagnetic = headingTrue - magneticVariation
-      if (headingMagnetic > Math.PI * 2) {
-        headingMagnetic -= Math.PI * 2
-      }
-      if (headingMagnetic < 0) {
-        headingMagnetic += Math.PI * 2
-      }
       return nmea.toSentence([
         '$IIVHW',
-        nmea.radsToDeg(headingTrue).toFixed(1),
+        nmea.radsToPositiveDeg(headingTrue).toFixed(1),
         'T',
-        nmea.radsToDeg(headingMagnetic).toFixed(1),
+        nmea.radsToPositiveDeg(headingMagnetic).toFixed(1),
         'M',
         nmea.msToKnots(speedThroughWater).toFixed(2),
         'N',

--- a/sentences/VPW.js
+++ b/sentences/VPW.js
@@ -4,7 +4,7 @@ $IIVPW,x.x,N,x.x,M*hh
        __I_Surface speed in knots
  */
 
-// NMEA0183 Encoder VPW   $IIVHW,6.5,N,12.64,M*48
+// NMEA0183 Encoder VPW   $IIVPW,6.5,N,12.64,M*48
 
 const nmea = require('../nmea.js')
 module.exports = function (app) {

--- a/sentences/VTG.js
+++ b/sentences/VTG.js
@@ -24,9 +24,9 @@ module.exports = function (app) {
     ) {
       return nmea.toSentence([
         '$IIVTG',
-        nmea.radsToDeg(courseOverGroundTrue).toFixed(2),
+        nmea.radsToPositiveDeg(courseOverGroundTrue).toFixed(2),
         'T',
-        nmea.radsToDeg(courseOverGroundMagnetic).toFixed(2),
+        nmea.radsToPositiveDeg(courseOverGroundMagnetic).toFixed(2),
         'M',
         nmea.msToKnots(speedOverGround).toFixed(2),
         'N',

--- a/sentences/XDRBaro.js
+++ b/sentences/XDRBaro.js
@@ -6,7 +6,7 @@
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {
-    title: 'XDR (Barometer) - Atomospheric Pressure',
+    title: 'XDR (Barometer) - Atmospheric Pressure',
     keys: ['environment.outside.pressure'],
     f: function (pressure) {
       return nmea.toSentence([

--- a/test/MWD.js
+++ b/test/MWD.js
@@ -51,6 +51,19 @@ describe('MWD', function () {
     pushMWD(app, (5 * Math.PI) / 180, (10 * Math.PI) / 180, 5)
   })
 
+  it('wraps magnetic direction when true near 360 and variation is westerly', (done) => {
+    // directionTrue = 355 deg (6.196 rad), variation = -10 deg (-0.175 rad)
+    // raw magnetic = 355 - (-10) = 365 deg (> 2*PI), fixAngle wraps to 5 deg
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[1], '355.00')
+      assert.equal(parts[3], '5.00')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'MWD')
+    pushMWD(app, (355 * Math.PI) / 180, (-10 * Math.PI) / 180, 5)
+  })
+
   it('produces positive true direction for negative radian input', (done) => {
     // directionTrue = -10 deg (equivalent to 350 deg), variation = 0
     const onEmit = (event, value) => {

--- a/test/RMB.js
+++ b/test/RMB.js
@@ -166,6 +166,22 @@ describe('RMB', function () {
     pushRmbStreams(app, {})
   })
 
+  it('does not emit when nextPoint has no position', (done) => {
+    let emitted = false
+    const onEmit = () => {
+      emitted = true
+    }
+    const app = createAppWithPlugin(onEmit, 'RMB')
+    // Push nextPoint without position (default is {}, which also has no position)
+    pushRmbStreams(app, {
+      nextPoint: { name: 'DEST' }
+    })
+    setTimeout(() => {
+      assert.equal(emitted, false)
+      done()
+    }, 50)
+  })
+
   it('subscribes to previousPoint for origin waypoint metadata', () => {
     const app = {
       streambundle: { getSelfStream: () => ({ toProperty: () => ({}) }) },

--- a/test/VTG.js
+++ b/test/VTG.js
@@ -1,0 +1,49 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+function parseSentence(sentence) {
+  const star = sentence.indexOf('*')
+  const body = star >= 0 ? sentence.substring(0, star) : sentence
+  return body.split(',')
+}
+
+function pushVTG(app, cogMagRad, cogTrueRad, sogMs) {
+  app.streambundle
+    .getSelfStream('navigation.courseOverGroundMagnetic')
+    .push(cogMagRad)
+  app.streambundle
+    .getSelfStream('navigation.courseOverGroundTrue')
+    .push(cogTrueRad)
+  app.streambundle.getSelfStream('navigation.speedOverGround').push(sogMs)
+}
+
+describe('VTG', function () {
+  it('emits COG true, COG magnetic, SOG in knots and km/h', (done) => {
+    // COG true = 90 deg, COG mag = 80 deg, SOG = 5 m/s
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[0], '$IIVTG')
+      assert.equal(parts[1], '90.00')
+      assert.equal(parts[2], 'T')
+      assert.equal(parts[3], '80.00')
+      assert.equal(parts[4], 'M')
+      assert.equal(parts[9], 'A')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VTG')
+    pushVTG(app, (80 * Math.PI) / 180, Math.PI / 2, 5)
+  })
+
+  it('produces positive degrees for negative radian COG inputs', (done) => {
+    // COG true = -10 deg (= 350 deg), COG mag = -20 deg (= 340 deg)
+    const onEmit = (event, value) => {
+      const parts = parseSentence(value)
+      assert.equal(parts[1], '350.00')
+      assert.equal(parts[3], '340.00')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'VTG')
+    pushVTG(app, (-20 * Math.PI) / 180, (-10 * Math.PI) / 180, 5)
+  })
+})


### PR DESCRIPTION
## Summary
- **VTG**: Replace `radsToDeg()` with `radsToPositiveDeg()` for COG true and COG magnetic fields. Same class of bug fixed in HDMC/MWD (#160) -- negative radian input produces invalid negative degrees in the NMEA sentence.
- **RMB**: Return early when `nextPoint` has no `position` coordinates. The `{}` default meant `wp.position?.latitude` evaluated to `undefined`, causing `toNmeaDegreesLatitude()` to throw at runtime.
- Remove dead code: `selfMatcher` (index.js), `fixAngle` (nmea.js, no longer used after #160)
- Remove commented-out `console.log` calls from MMB, MTA, PNKEP01, PNKEP02, PNKEP99
- Fix typos: VPW comment (`$IIVHW` -> `$IIVPW`), XDRBaro title ("Atomospheric"), MWVR title ("Aparent")

## Test plan
- [x] `npm test` -- all 77 tests pass (3 new)
- [x] New VTG tests: normal values + negative radian edge case
- [x] New RMB test: no emission when nextPoint lacks position