### PR TITLE
fix: use correct SK path angleTrueWater in PNKEP99

### DIFF
--- a/sentences/PNKEP99.js
+++ b/sentences/PNKEP99.js
@@ -5,7 +5,7 @@ module.exports = function (app) {
     keys: [
       'environment.wind.angleApparent',
       'environment.wind.speedApparent',
-      'environment.wind.angleTrue',
+      'environment.wind.angleTrueWater',
       'environment.wind.speedTrue',
       'navigation.speedThroughWater',
       'performance.polarSpeed',


### PR DESCRIPTION
## Summary
- PNKEP99 subscribed to `environment.wind.angleTrue` which does not exist in the Signal K specification
- The spec defines `environment.wind.angleTrueGround` and `environment.wind.angleTrueWater`
- The function parameter was already named `angleTrueWater`, confirming the intended path
- Changed the key to `environment.wind.angleTrueWater`

## Test plan
- [x] `npm test` -- all 81 tests pass
- [x] Single-line change, no behavioral impact unless the server was somehow providing data on the non-spec path