### PR TITLE
Fix license field in package.json to match LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "signalk-node-server-plugin"
   ],
   "author": "teppo.kurki@iki.fi",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "devDependencies": {
     "baconjs": "^3.0.0",
     "c8": "^11.0.0",


### PR DESCRIPTION
## Summary
- Changes `"license": "ISC"` to `"license": "Apache-2.0"` in `package.json` to match the actual `LICENSE` file.
- This fixes the npm/shields.io badge in the README showing ISC instead of Apache-2.0.

Fixes #166