### PR TITLE
feat: add APB_magneticBearings config option for legacy autopilot compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = function (app) {
   }
 
   plugin.start = function (options) {
+    plugin.options = options
     function mapToNmea(encoder, throttle) {
       const selfStreams = encoder.keys.map((key, index) => {
         let stream = app.streambundle.getSelfStream(key)
@@ -107,6 +108,9 @@ function buildSchemaFromSentences(plugin) {
       title: `${key} throttle ms`,
       type: 'number',
       default: 0
+    }
+    if (sentence.optionProperties) {
+      Object.assign(plugin.schema.properties, sentence.optionProperties)
     }
   })
 }

--- a/sentences/APB.js
+++ b/sentences/APB.js
@@ -31,26 +31,47 @@
       14. M = Magnetic, T = True
       15. Checksum
 
-      Example: $GPAPB,A,A,0.10,R,N,V,V,011,T,DEST,011,T,011,T*82
+      Bearing reference (T or M) is controlled by the APB_magneticBearings
+      config option.  Default is True, matching pypilot and modern GPS
+      autopilots.  Enable magnetic for legacy autopilots (e.g. Raymarine
+      SeaTalk 1) that need magnetic bearings -- they also need variation
+      from HDG or RMC to convert if this option is off.
     */
 const nmea = require('../nmea.js')
-module.exports = function (app) {
+module.exports = function (app, plugin) {
   return {
     sentence: 'APB',
     title: 'APB - Autopilot info',
+    optionProperties: {
+      APB_magneticBearings: {
+        title: 'APB: use magnetic bearings (for legacy autopilots)',
+        type: 'boolean',
+        default: false
+      }
+    },
     keys: [
       'navigation.course.calcValues.crossTrackError',
       'navigation.course.calcValues.bearingTrackTrue',
       'navigation.course.calcValues.bearingTrue',
-      'navigation.course.nextPoint'
+      'navigation.course.nextPoint',
+      'navigation.magneticVariation'
     ],
-    // nextPoint defaults to {} so APB still fires when only calcValues are
-    // available (the common case today). Once signalk-server populates
-    // nextPoint.name (see SignalK/signalk-server#2595, SignalK/specification#676),
-    // the waypoint identifier will flow through automatically.
-    defaults: [undefined, undefined, undefined, {}],
-    f: function (xte, originToDest, bearingTrue, nextPoint) {
+    defaults: [undefined, undefined, undefined, {}, null],
+    f: function (xte, originToDest, bearingTrue, nextPoint, magneticVariation) {
       var waypointId = (nextPoint && nextPoint.name) || ''
+      var useMagnetic =
+        plugin.options &&
+        plugin.options.APB_magneticBearings &&
+        typeof magneticVariation === 'number'
+      var ref = useMagnetic ? 'M' : 'T'
+      var brg1 = useMagnetic
+        ? nmea.radsToPositiveDeg(
+            nmea.fixAngle(originToDest - magneticVariation)
+          )
+        : nmea.radsToPositiveDeg(originToDest)
+      var brg2 = useMagnetic
+        ? nmea.radsToPositiveDeg(nmea.fixAngle(bearingTrue - magneticVariation))
+        : nmea.radsToPositiveDeg(bearingTrue)
       return nmea.toSentence([
         '$IIAPB',
         'A',
@@ -60,13 +81,13 @@ module.exports = function (app) {
         'N',
         'V',
         'V',
-        nmea.radsToPositiveDeg(originToDest).toFixed(0),
-        'T',
+        brg1.toFixed(0),
+        ref,
         waypointId,
-        nmea.radsToPositiveDeg(bearingTrue).toFixed(0),
-        'T',
-        nmea.radsToPositiveDeg(bearingTrue).toFixed(0),
-        'T'
+        brg2.toFixed(0),
+        ref,
+        brg2.toFixed(0),
+        ref
       ])
     }
   }

--- a/test/APB.js
+++ b/test/APB.js
@@ -7,19 +7,22 @@ describe('APB', function () {
   //   crossTrackError = -39.84 m (left of track)
   //   bearingTrackTrue = 2.1503 rad (123 deg)
   //   bearingTrue = 2.1962 rad (126 deg)
+  //   magneticVariation = -0.16 rad (-9.17 deg, westerly)
   const realXte = -39.84
   const realBearingTrackTrue = 2.1503
   const realBearingTrue = 2.1962
+  const realVariation = -0.16
 
   function pushApbStreams(app, overrides) {
-    // Push nextPoint before calcValues so it is already present when the
-    // combined stream fires. The nextPoint key has a default of {}, so
-    // pushing calcValues alone would emit immediately with that default
-    // and debounce the subsequent nextPoint update.
     if ('nextPoint' in overrides) {
       app.streambundle
         .getSelfStream('navigation.course.nextPoint')
         .push(overrides.nextPoint)
+    }
+    if ('magneticVariation' in overrides) {
+      app.streambundle
+        .getSelfStream('navigation.magneticVariation')
+        .push(overrides.magneticVariation)
     }
     const calcValues = {
       'navigation.course.calcValues.crossTrackError':
@@ -38,7 +41,7 @@ describe('APB', function () {
     const body = sentence.split('*')[0]
     const parts = body.split(',')
     return {
-      talker: parts[0], // $IIAPB
+      talker: parts[0],
       status1: parts[1],
       status2: parts[2],
       xteMagnitude: parts[3],
@@ -56,85 +59,60 @@ describe('APB', function () {
     }
   }
 
-  it('emits a valid APB sentence with real navigation data', (done) => {
+  it('defaults to True bearings for all three pairs', (done) => {
     const onEmit = (event, value) => {
       const fields = parseApb(value)
-      assert.equal(fields.status1, 'A')
-      assert.equal(fields.status2, 'A')
-      assert.equal(fields.xteUnits, 'N')
-      assert.equal(fields.bearingOriginToDestRef, 'T')
+      assert.equal(fields.bearingOriginToDestRef, 'T', 'field 9')
+      assert.equal(fields.bearingPosToDestRef, 'T', 'field 12')
+      assert.equal(fields.headingToSteerRef, 'T', 'field 14')
+      assert.equal(fields.bearingOriginToDest, '123')
+      assert.equal(fields.bearingPosToDest, '126')
+      assert.equal(fields.headingToSteer, '126')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'APB')
     pushApbStreams(app, {})
   })
 
-  it('subscribes to navigation.course.nextPoint for waypoint metadata', () => {
-    // The APB generator must subscribe to the nextPoint path so that it can
-    // read the destination waypoint name and populate NMEA field 10 (Waypoint
-    // ID). Without this subscription, there is no source for the waypoint
-    // identifier and field 10 has to be hardcoded.
-    const app = {
-      streambundle: { getSelfStream: () => ({ toProperty: () => ({}) }) },
-      emit: () => {},
-      debug: () => {}
-    }
-    const apb = require('../sentences/APB')(app)
-    assert.ok(
-      apb.keys.includes('navigation.course.nextPoint'),
-      'APB keys should include navigation.course.nextPoint, got: ' +
-        JSON.stringify(apb.keys)
-    )
-  })
-
-  it('uses waypoint name in field 10 when nextPoint has a name', (done) => {
-    // When Signal K provides a named waypoint (e.g. user navigated to a saved
-    // waypoint via the Course API), the name should appear in APB field 10
-    // (Destination Waypoint ID) so the autopilot can display it.
+  it('uses magnetic bearings when APB_magneticBearings is enabled', (done) => {
+    // variation = -0.16 rad = -9.17 deg (westerly)
+    // magnetic = true - variation = true - (-0.16) = true + 0.16
+    // bearingTrackTrue 123 deg -> magnetic 132 deg
+    // bearingTrue 126 deg -> magnetic 135 deg
     const onEmit = (event, value) => {
       const fields = parseApb(value)
-      assert.equal(
-        fields.waypointId,
-        'NASSAU',
-        'field 10 should contain the waypoint name from nextPoint'
-      )
+      assert.equal(fields.bearingOriginToDestRef, 'M', 'field 9')
+      assert.equal(fields.bearingPosToDestRef, 'M', 'field 12')
+      assert.equal(fields.headingToSteerRef, 'M', 'field 14')
+      assert.equal(fields.bearingOriginToDest, '132')
+      assert.equal(fields.bearingPosToDest, '135')
+      assert.equal(fields.headingToSteer, '135')
       done()
     }
-    const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, {
-      nextPoint: {
-        position: { latitude: 25.04133, longitude: -77.24333 },
-        type: 'Waypoint',
-        name: 'NASSAU'
-      }
+    const app = createAppWithPlugin(onEmit, {
+      APB: true,
+      APB_magneticBearings: true
     })
+    pushApbStreams(app, { magneticVariation: realVariation })
   })
 
-  it('uses empty field 10 when nextPoint has no name', (done) => {
-    // Route points typically have no name (just type: "RoutePoint" and a
-    // position). NMEA allows empty fields, so field 10 should be empty rather
-    // than a meaningless placeholder like "00".
+  it('falls back to True when magnetic is enabled but variation is unavailable', (done) => {
     const onEmit = (event, value) => {
       const fields = parseApb(value)
-      assert.equal(
-        fields.waypointId,
-        '',
-        'field 10 should be empty when no waypoint name is available'
-      )
+      assert.equal(fields.bearingOriginToDestRef, 'T', 'field 9')
+      assert.equal(fields.bearingPosToDestRef, 'T', 'field 12')
+      assert.equal(fields.headingToSteerRef, 'T', 'field 14')
       done()
     }
-    const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, {
-      nextPoint: {
-        position: { latitude: 25.04133, longitude: -77.24333 },
-        type: 'RoutePoint'
-      }
+    const app = createAppWithPlugin(onEmit, {
+      APB: true,
+      APB_magneticBearings: true
     })
+    // magneticVariation defaults to null, never pushed
+    pushApbStreams(app, {})
   })
 
-  it('computes correct XTE and steer direction from real data', (done) => {
-    // XTE = -39.84 m means vessel is left of track, steer Right.
-    // Magnitude in NM: 39.84 * 0.000539957 = 0.022 NM
+  it('computes correct XTE and steer direction', (done) => {
     const onEmit = (event, value) => {
       const fields = parseApb(value)
       assert.equal(fields.steerDirection, 'R', 'negative XTE = steer right')
@@ -145,60 +123,52 @@ describe('APB', function () {
     pushApbStreams(app, {})
   })
 
-  it('computes bearings in degrees from radians', (done) => {
-    // bearingTrackTrue = 2.1503 rad = 123 deg
-    // bearingTrue = 2.1962 rad = 126 deg
-    // All three bearing pairs use True (fields 9, 12, 14 = 'T').
-    // Heading to steer (field 13) equals bearingTrue, not bearingMagnetic.
+  it('uses waypoint name in field 10 when nextPoint has a name', (done) => {
     const onEmit = (event, value) => {
       const fields = parseApb(value)
-      assert.equal(fields.bearingOriginToDest, '123')
-      assert.equal(fields.bearingPosToDest, '126')
-      assert.equal(fields.headingToSteer, '126')
+      assert.equal(fields.waypointId, 'NASSAU')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, {})
+    pushApbStreams(app, {
+      nextPoint: {
+        position: { latitude: 25.04133, longitude: -77.24333 },
+        name: 'NASSAU'
+      }
+    })
   })
 
-  it('uses True reference for all three bearing pairs', (done) => {
-    // NMEA APB carries three bearing pairs (fields 8-9, 11-12, 13-14).
-    // All must use the same reference system. This plugin uses True for all
-    // three, which is correct for autopilots with a true heading source and
-    // matches the convention used by RMB in this repo.
+  it('uses empty field 10 when nextPoint has no name', (done) => {
     const onEmit = (event, value) => {
       const fields = parseApb(value)
-      assert.equal(fields.bearingOriginToDestRef, 'T', 'field 9')
-      assert.equal(fields.bearingPosToDestRef, 'T', 'field 12')
-      assert.equal(fields.headingToSteerRef, 'T', 'field 14')
+      assert.equal(fields.waypointId, '')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, {})
+    pushApbStreams(app, {
+      nextPoint: { position: { latitude: 25.04, longitude: -77.24 } }
+    })
   })
 
-  it('steers Left when XTE is positive (vessel right of track)', (done) => {
+  it('never mixes T and M within a single sentence', (done) => {
     const onEmit = (event, value) => {
       const fields = parseApb(value)
-      assert.equal(fields.steerDirection, 'L', 'positive XTE = steer left')
-      assert.equal(fields.xteMagnitude, '0.054')
+      assert.equal(
+        fields.bearingOriginToDestRef,
+        fields.bearingPosToDestRef,
+        'fields 9 and 12 must match'
+      )
+      assert.equal(
+        fields.bearingPosToDestRef,
+        fields.headingToSteerRef,
+        'fields 12 and 14 must match'
+      )
       done()
     }
-    const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, { crossTrackError: 100 })
-  })
-
-  it('does not subscribe to bearingMagnetic', () => {
-    const app = {
-      streambundle: { getSelfStream: () => ({ toProperty: () => ({}) }) },
-      emit: () => {},
-      debug: () => {}
-    }
-    const apb = require('../sentences/APB')(app)
-    assert.ok(
-      !apb.keys.includes('navigation.course.calcValues.bearingMagnetic'),
-      'APB should not subscribe to bearingMagnetic, got: ' +
-        JSON.stringify(apb.keys)
-    )
+    const app = createAppWithPlugin(onEmit, {
+      APB: true,
+      APB_magneticBearings: true
+    })
+    pushApbStreams(app, { magneticVariation: realVariation })
   })
 })


### PR DESCRIPTION
## Summary

Adds a config toggle for APB bearing references, matching OpenCPN's approach (`g_bMagneticAPB`).

**Problem:** pypilot rejects APB sentences with Magnetic (M) references. Raymarine SeaTalk 1 autopilots prefer Magnetic or need variation from HDG/RMC to convert True. PR #144 switched to all-True which broke some legacy setups.

**Solution:** Config option, never mixed references.

| `APB_magneticBearings` | Fields 9, 12, 14 | Variation needed | Compatible with |
|---|---|---|---|
| `false` (default) | T | No | pypilot, modern autopilots, Raymarine with HDG/RMC variation |
| `true` | M | Yes (falls back to T if unavailable) | Raymarine SeaTalk 1 without other variation source |

All three bearing pairs always use the same reference. This matches the de facto standard confirmed across OpenCPN, go-nmea, and every real chart plotter.

### Implementation
- APB now subscribes to `navigation.magneticVariation` (defaults to null, does not block emission)
- `plugin.options` is stored in `start()` so sentence generators can read config at emission time
- Generic `optionProperties` mechanism in `buildSchemaFromSentences` for sentence-specific config (reusable by other sentences)

## Test plan
- [x] `npm test` -- 79 tests pass
- [x] Default (True): all three refs = T, correct bearing values
- [x] Magnetic enabled: all three refs = M, bearings offset by variation
- [x] Magnetic enabled but no variation: falls back to T
- [x] Never-mixed invariant test