### PR TITLE
feat: add APB-magnetic sentence for legacy autopilots

### DIFF
--- a/sentences/APB-magnetic.js
+++ b/sentences/APB-magnetic.js
@@ -1,0 +1,49 @@
+/*
+      APB with all bearings in Magnetic, computed from True bearings and
+      magneticVariation.  Same field layout as APB.js but with M references.
+
+      Enable this instead of APB for legacy autopilots (e.g. Raymarine
+      SeaTalk 1) that require magnetic bearings.  Do not enable both APB
+      and APB-magnetic at the same time.
+    */
+const nmea = require('../nmea.js')
+module.exports = function (app) {
+  return {
+    sentence: 'APB',
+    title: 'APB - Autopilot info (magnetic bearings)',
+    keys: [
+      'navigation.course.calcValues.crossTrackError',
+      'navigation.course.calcValues.bearingTrackTrue',
+      'navigation.course.calcValues.bearingTrue',
+      'navigation.course.nextPoint',
+      'navigation.magneticVariation'
+    ],
+    defaults: [undefined, undefined, undefined, {}, undefined],
+    f: function (xte, originToDest, bearingTrue, nextPoint, magneticVariation) {
+      var waypointId = (nextPoint && nextPoint.name) || ''
+      var brg1 = nmea.radsToPositiveDeg(
+        nmea.fixAngle(originToDest - magneticVariation)
+      )
+      var brg2 = nmea.radsToPositiveDeg(
+        nmea.fixAngle(bearingTrue - magneticVariation)
+      )
+      return nmea.toSentence([
+        '$IIAPB',
+        'A',
+        'A',
+        Math.abs(nmea.mToNm(xte)).toFixed(3),
+        xte > 0 ? 'L' : 'R',
+        'N',
+        'V',
+        'V',
+        brg1.toFixed(0),
+        'M',
+        waypointId,
+        brg2.toFixed(0),
+        'M',
+        brg2.toFixed(0),
+        'M'
+      ])
+    }
+  }
+}

--- a/test/APB-magnetic.js
+++ b/test/APB-magnetic.js
@@ -1,0 +1,94 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+describe('APB-magnetic', function () {
+  // bearingTrackTrue = 2.1503 rad (123 deg)
+  // bearingTrue = 2.1962 rad (126 deg)
+  // magneticVariation = -0.16 rad (-9.17 deg, westerly)
+  // magnetic = true - variation = true - (-0.16) = true + 0.16
+  // bearingTrackMag = 123 + 9 = 132 deg
+  // bearingMag = 126 + 9 = 135 deg
+  const realXte = -39.84
+  const realBearingTrackTrue = 2.1503
+  const realBearingTrue = 2.1962
+  const realVariation = -0.16
+
+  function pushStreams(app) {
+    app.streambundle
+      .getSelfStream('navigation.magneticVariation')
+      .push(realVariation)
+    app.streambundle
+      .getSelfStream('navigation.course.calcValues.crossTrackError')
+      .push(realXte)
+    app.streambundle
+      .getSelfStream('navigation.course.calcValues.bearingTrackTrue')
+      .push(realBearingTrackTrue)
+    app.streambundle
+      .getSelfStream('navigation.course.calcValues.bearingTrue')
+      .push(realBearingTrue)
+  }
+
+  function parseApb(sentence) {
+    const body = sentence.split('*')[0]
+    const parts = body.split(',')
+    return {
+      talker: parts[0],
+      bearingOriginToDest: parts[8],
+      bearingOriginToDestRef: parts[9],
+      waypointId: parts[10],
+      bearingPosToDest: parts[11],
+      bearingPosToDestRef: parts[12],
+      headingToSteer: parts[13],
+      headingToSteerRef: parts[14]
+    }
+  }
+
+  it('uses Magnetic reference for all three bearing pairs', (done) => {
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(fields.bearingOriginToDestRef, 'M', 'field 9')
+      assert.equal(fields.bearingPosToDestRef, 'M', 'field 12')
+      assert.equal(fields.headingToSteerRef, 'M', 'field 14')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB-magnetic')
+    pushStreams(app)
+  })
+
+  it('computes magnetic bearings from true bearings and variation', (done) => {
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(fields.bearingOriginToDest, '132')
+      assert.equal(fields.bearingPosToDest, '135')
+      assert.equal(fields.headingToSteer, '135')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB-magnetic')
+    pushStreams(app)
+  })
+
+  it('wraps magnetic bearing when near 360', (done) => {
+    // bearingTrue = 355 deg (6.196 rad), variation = -10 deg (-0.175 rad)
+    // magnetic = 355 - (-10) = 365 -> wraps to 5 deg
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(fields.headingToSteer, '5')
+      assert.equal(fields.headingToSteerRef, 'M')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB-magnetic')
+    app.streambundle
+      .getSelfStream('navigation.magneticVariation')
+      .push((-10 * Math.PI) / 180)
+    app.streambundle
+      .getSelfStream('navigation.course.calcValues.crossTrackError')
+      .push(realXte)
+    app.streambundle
+      .getSelfStream('navigation.course.calcValues.bearingTrackTrue')
+      .push((350 * Math.PI) / 180)
+    app.streambundle
+      .getSelfStream('navigation.course.calcValues.bearingTrue')
+      .push((355 * Math.PI) / 180)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `APB-magnetic.js` alongside the existing `APB.js`, following the same pattern as HDM/HDMC, HDT/HDTC, DPT/DPT-surface.

| Sentence | Bearings | Subscribes to variation | Use case |
|---|---|---|---|
| **APB** (existing) | True (T) | No | pypilot, modern autopilots |
| **APB-magnetic** (new) | Magnetic (M) | Yes | Raymarine SeaTalk 1, legacy autopilots |

Both produce `$IIAPB` with all three bearing pairs using the same reference (never mixed). Users enable one or the other in plugin settings.

Replaces the config-option approach from #169 with a simpler, pattern-consistent design. No changes to index.js or the plugin framework.

## Test plan
- [x] `npm test` -- 84 tests pass (3 new for APB-magnetic)
- [x] All-M references verified
- [x] Magnetic computation from true + variation verified
- [x] Wrap at 360 deg boundary verified