### PR TITLE
fix: restore APB to magnetic bearings, add APB-true for pypilot

### DIFF
--- a/sentences/APB-true.js
+++ b/sentences/APB-true.js
@@ -31,33 +31,29 @@
       14. M = Magnetic, T = True
       15. Checksum
 
-      All three bearing pairs use Magnetic, computed from True bearings
-      and magneticVariation.  For autopilots that require True bearings
-      use APB-true instead.
+      All three bearing pairs use True.  For autopilots that require
+      Magnetic bearings use APB instead.
 
-      Example: $GPAPB,A,A,0.10,R,N,V,V,011,M,DEST,011,M,011,M*82
+      Example: $GPAPB,A,A,0.10,R,N,V,V,011,T,DEST,011,T,011,T*82
     */
 const nmea = require('../nmea.js')
 module.exports = function (app) {
   return {
     sentence: 'APB',
-    title: 'APB - Autopilot info (magnetic bearings)',
+    title: 'APB - Autopilot info (true bearings)',
     keys: [
       'navigation.course.calcValues.crossTrackError',
       'navigation.course.calcValues.bearingTrackTrue',
       'navigation.course.calcValues.bearingTrue',
-      'navigation.course.nextPoint',
-      'navigation.magneticVariation'
+      'navigation.course.nextPoint'
     ],
-    defaults: [undefined, undefined, undefined, {}, undefined],
-    f: function (xte, originToDest, bearingTrue, nextPoint, magneticVariation) {
+    // nextPoint defaults to {} so APB still fires when only calcValues are
+    // available (the common case today). Once signalk-server populates
+    // nextPoint.name (see SignalK/signalk-server#2595, SignalK/specification#676),
+    // the waypoint identifier will flow through automatically.
+    defaults: [undefined, undefined, undefined, {}],
+    f: function (xte, originToDest, bearingTrue, nextPoint) {
       var waypointId = (nextPoint && nextPoint.name) || ''
-      var bearingOriginToDestMag = nmea.radsToPositiveDeg(
-        nmea.fixAngle(originToDest - magneticVariation)
-      )
-      var bearingToDestMag = nmea.radsToPositiveDeg(
-        nmea.fixAngle(bearingTrue - magneticVariation)
-      )
       return nmea.toSentence([
         '$IIAPB',
         'A',
@@ -67,13 +63,13 @@ module.exports = function (app) {
         'N',
         'V',
         'V',
-        bearingOriginToDestMag.toFixed(0),
-        'M',
+        nmea.radsToPositiveDeg(originToDest).toFixed(0),
+        'T',
         waypointId,
-        bearingToDestMag.toFixed(0),
-        'M',
-        bearingToDestMag.toFixed(0),
-        'M'
+        nmea.radsToPositiveDeg(bearingTrue).toFixed(0),
+        'T',
+        nmea.radsToPositiveDeg(bearingTrue).toFixed(0),
+        'T'
       ])
     }
   }

--- a/test/APB-true.js
+++ b/test/APB-true.js
@@ -1,0 +1,204 @@
+const assert = require('assert')
+
+const { createAppWithPlugin } = require('./testutil')
+
+describe('APB-true', function () {
+  // Real navigation data: route near Nassau, Bahamas.
+  //   crossTrackError = -39.84 m (left of track)
+  //   bearingTrackTrue = 2.1503 rad (123 deg)
+  //   bearingTrue = 2.1962 rad (126 deg)
+  const realXte = -39.84
+  const realBearingTrackTrue = 2.1503
+  const realBearingTrue = 2.1962
+
+  function pushApbStreams(app, overrides) {
+    // Push nextPoint before calcValues so it is already present when the
+    // combined stream fires. The nextPoint key has a default of {}, so
+    // pushing calcValues alone would emit immediately with that default
+    // and debounce the subsequent nextPoint update.
+    if ('nextPoint' in overrides) {
+      app.streambundle
+        .getSelfStream('navigation.course.nextPoint')
+        .push(overrides.nextPoint)
+    }
+    const calcValues = {
+      'navigation.course.calcValues.crossTrackError':
+        overrides.crossTrackError ?? realXte,
+      'navigation.course.calcValues.bearingTrackTrue':
+        overrides.bearingTrackTrue ?? realBearingTrackTrue,
+      'navigation.course.calcValues.bearingTrue':
+        overrides.bearingTrue ?? realBearingTrue
+    }
+    for (const [path, value] of Object.entries(calcValues)) {
+      app.streambundle.getSelfStream(path).push(value)
+    }
+  }
+
+  function parseApb(sentence) {
+    const body = sentence.split('*')[0]
+    const parts = body.split(',')
+    return {
+      talker: parts[0], // $IIAPB
+      status1: parts[1],
+      status2: parts[2],
+      xteMagnitude: parts[3],
+      steerDirection: parts[4],
+      xteUnits: parts[5],
+      arrivalCircle: parts[6],
+      perpendicularPassed: parts[7],
+      bearingOriginToDest: parts[8],
+      bearingOriginToDestRef: parts[9],
+      waypointId: parts[10],
+      bearingPosToDest: parts[11],
+      bearingPosToDestRef: parts[12],
+      headingToSteer: parts[13],
+      headingToSteerRef: parts[14]
+    }
+  }
+
+  it('emits a valid APB sentence with real navigation data', (done) => {
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(fields.status1, 'A')
+      assert.equal(fields.status2, 'A')
+      assert.equal(fields.xteUnits, 'N')
+      assert.equal(fields.bearingOriginToDestRef, 'T')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB-true')
+    pushApbStreams(app, {})
+  })
+
+  it('subscribes to navigation.course.nextPoint for waypoint metadata', () => {
+    // The APB generator must subscribe to the nextPoint path so that it can
+    // read the destination waypoint name and populate NMEA field 10 (Waypoint
+    // ID). Without this subscription, there is no source for the waypoint
+    // identifier and field 10 has to be hardcoded.
+    const app = {
+      streambundle: { getSelfStream: () => ({ toProperty: () => ({}) }) },
+      emit: () => {},
+      debug: () => {}
+    }
+    const apb = require('../sentences/APB-true')(app)
+    assert.ok(
+      apb.keys.includes('navigation.course.nextPoint'),
+      'APB keys should include navigation.course.nextPoint, got: ' +
+        JSON.stringify(apb.keys)
+    )
+  })
+
+  it('uses waypoint name in field 10 when nextPoint has a name', (done) => {
+    // When Signal K provides a named waypoint (e.g. user navigated to a saved
+    // waypoint via the Course API), the name should appear in APB field 10
+    // (Destination Waypoint ID) so the autopilot can display it.
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(
+        fields.waypointId,
+        'NASSAU',
+        'field 10 should contain the waypoint name from nextPoint'
+      )
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB-true')
+    pushApbStreams(app, {
+      nextPoint: {
+        position: { latitude: 25.04133, longitude: -77.24333 },
+        type: 'Waypoint',
+        name: 'NASSAU'
+      }
+    })
+  })
+
+  it('uses empty field 10 when nextPoint has no name', (done) => {
+    // Route points typically have no name (just type: "RoutePoint" and a
+    // position). NMEA allows empty fields, so field 10 should be empty rather
+    // than a meaningless placeholder like "00".
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(
+        fields.waypointId,
+        '',
+        'field 10 should be empty when no waypoint name is available'
+      )
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB-true')
+    pushApbStreams(app, {
+      nextPoint: {
+        position: { latitude: 25.04133, longitude: -77.24333 },
+        type: 'RoutePoint'
+      }
+    })
+  })
+
+  it('computes correct XTE and steer direction from real data', (done) => {
+    // XTE = -39.84 m means vessel is left of track, steer Right.
+    // Magnitude in NM: 39.84 * 0.000539957 = 0.022 NM
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(fields.steerDirection, 'R', 'negative XTE = steer right')
+      assert.equal(fields.xteMagnitude, '0.022')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB-true')
+    pushApbStreams(app, {})
+  })
+
+  it('computes bearings in degrees from radians', (done) => {
+    // bearingTrackTrue = 2.1503 rad = 123 deg
+    // bearingTrue = 2.1962 rad = 126 deg
+    // All three bearing pairs use True (fields 9, 12, 14 = 'T').
+    // Heading to steer (field 13) equals bearingTrue, not bearingMagnetic.
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(fields.bearingOriginToDest, '123')
+      assert.equal(fields.bearingPosToDest, '126')
+      assert.equal(fields.headingToSteer, '126')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB-true')
+    pushApbStreams(app, {})
+  })
+
+  it('uses True reference for all three bearing pairs', (done) => {
+    // NMEA APB carries three bearing pairs (fields 8-9, 11-12, 13-14).
+    // All must use the same reference system. This plugin uses True for all
+    // three, which is correct for autopilots with a true heading source and
+    // matches the convention used by RMB in this repo.
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(fields.bearingOriginToDestRef, 'T', 'field 9')
+      assert.equal(fields.bearingPosToDestRef, 'T', 'field 12')
+      assert.equal(fields.headingToSteerRef, 'T', 'field 14')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB-true')
+    pushApbStreams(app, {})
+  })
+
+  it('steers Left when XTE is positive (vessel right of track)', (done) => {
+    const onEmit = (event, value) => {
+      const fields = parseApb(value)
+      assert.equal(fields.steerDirection, 'L', 'positive XTE = steer left')
+      assert.equal(fields.xteMagnitude, '0.054')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB-true')
+    pushApbStreams(app, { crossTrackError: 100 })
+  })
+
+  it('does not subscribe to bearingMagnetic', () => {
+    const app = {
+      streambundle: { getSelfStream: () => ({ toProperty: () => ({}) }) },
+      emit: () => {},
+      debug: () => {}
+    }
+    const apb = require('../sentences/APB-true')(app)
+    assert.ok(
+      !apb.keys.includes('navigation.course.calcValues.bearingMagnetic'),
+      'APB should not subscribe to bearingMagnetic, got: ' +
+        JSON.stringify(apb.keys)
+    )
+  })
+})

--- a/test/APB.js
+++ b/test/APB.js
@@ -2,50 +2,44 @@ const assert = require('assert')
 
 const { createAppWithPlugin } = require('./testutil')
 
-describe('APB', function () {
-  // Real navigation data: route near Nassau, Bahamas.
-  //   crossTrackError = -39.84 m (left of track)
-  //   bearingTrackTrue = 2.1503 rad (123 deg)
-  //   bearingTrue = 2.1962 rad (126 deg)
+describe('APB (magnetic)', function () {
+  // bearingTrackTrue = 2.1503 rad (123 deg)
+  // bearingTrue = 2.1962 rad (126 deg)
+  // magneticVariation = -0.16 rad (-9.17 deg, westerly)
+  // magnetic = true - variation = true + 9.17
+  // bearingTrackMag = 132 deg, bearingMag = 135 deg
   const realXte = -39.84
   const realBearingTrackTrue = 2.1503
   const realBearingTrue = 2.1962
+  const realVariation = -0.16
 
-  function pushApbStreams(app, overrides) {
-    // Push nextPoint before calcValues so it is already present when the
-    // combined stream fires. The nextPoint key has a default of {}, so
-    // pushing calcValues alone would emit immediately with that default
-    // and debounce the subsequent nextPoint update.
-    if ('nextPoint' in overrides) {
+  function pushStreams(app, overrides) {
+    if (overrides && 'nextPoint' in overrides) {
       app.streambundle
         .getSelfStream('navigation.course.nextPoint')
         .push(overrides.nextPoint)
     }
-    const calcValues = {
-      'navigation.course.calcValues.crossTrackError':
-        overrides.crossTrackError ?? realXte,
-      'navigation.course.calcValues.bearingTrackTrue':
-        overrides.bearingTrackTrue ?? realBearingTrackTrue,
-      'navigation.course.calcValues.bearingTrue':
-        overrides.bearingTrue ?? realBearingTrue
-    }
-    for (const [path, value] of Object.entries(calcValues)) {
-      app.streambundle.getSelfStream(path).push(value)
-    }
+    app.streambundle
+      .getSelfStream('navigation.magneticVariation')
+      .push((overrides && overrides.magneticVariation) ?? realVariation)
+    app.streambundle
+      .getSelfStream('navigation.course.calcValues.crossTrackError')
+      .push((overrides && overrides.crossTrackError) ?? realXte)
+    app.streambundle
+      .getSelfStream('navigation.course.calcValues.bearingTrackTrue')
+      .push((overrides && overrides.bearingTrackTrue) ?? realBearingTrackTrue)
+    app.streambundle
+      .getSelfStream('navigation.course.calcValues.bearingTrue')
+      .push((overrides && overrides.bearingTrue) ?? realBearingTrue)
   }
 
   function parseApb(sentence) {
     const body = sentence.split('*')[0]
     const parts = body.split(',')
     return {
-      talker: parts[0], // $IIAPB
-      status1: parts[1],
-      status2: parts[2],
+      talker: parts[0],
       xteMagnitude: parts[3],
       steerDirection: parts[4],
-      xteUnits: parts[5],
-      arrivalCircle: parts[6],
-      perpendicularPassed: parts[7],
       bearingOriginToDest: parts[8],
       bearingOriginToDestRef: parts[9],
       waypointId: parts[10],
@@ -56,85 +50,31 @@ describe('APB', function () {
     }
   }
 
-  it('emits a valid APB sentence with real navigation data', (done) => {
+  it('uses Magnetic reference for all three bearing pairs', (done) => {
     const onEmit = (event, value) => {
       const fields = parseApb(value)
-      assert.equal(fields.status1, 'A')
-      assert.equal(fields.status2, 'A')
-      assert.equal(fields.xteUnits, 'N')
-      assert.equal(fields.bearingOriginToDestRef, 'T')
+      assert.equal(fields.bearingOriginToDestRef, 'M', 'field 9')
+      assert.equal(fields.bearingPosToDestRef, 'M', 'field 12')
+      assert.equal(fields.headingToSteerRef, 'M', 'field 14')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, {})
+    pushStreams(app)
   })
 
-  it('subscribes to navigation.course.nextPoint for waypoint metadata', () => {
-    // The APB generator must subscribe to the nextPoint path so that it can
-    // read the destination waypoint name and populate NMEA field 10 (Waypoint
-    // ID). Without this subscription, there is no source for the waypoint
-    // identifier and field 10 has to be hardcoded.
-    const app = {
-      streambundle: { getSelfStream: () => ({ toProperty: () => ({}) }) },
-      emit: () => {},
-      debug: () => {}
-    }
-    const apb = require('../sentences/APB')(app)
-    assert.ok(
-      apb.keys.includes('navigation.course.nextPoint'),
-      'APB keys should include navigation.course.nextPoint, got: ' +
-        JSON.stringify(apb.keys)
-    )
-  })
-
-  it('uses waypoint name in field 10 when nextPoint has a name', (done) => {
-    // When Signal K provides a named waypoint (e.g. user navigated to a saved
-    // waypoint via the Course API), the name should appear in APB field 10
-    // (Destination Waypoint ID) so the autopilot can display it.
+  it('computes magnetic bearings from true and variation', (done) => {
     const onEmit = (event, value) => {
       const fields = parseApb(value)
-      assert.equal(
-        fields.waypointId,
-        'NASSAU',
-        'field 10 should contain the waypoint name from nextPoint'
-      )
+      assert.equal(fields.bearingOriginToDest, '132')
+      assert.equal(fields.bearingPosToDest, '135')
+      assert.equal(fields.headingToSteer, '135')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, {
-      nextPoint: {
-        position: { latitude: 25.04133, longitude: -77.24333 },
-        type: 'Waypoint',
-        name: 'NASSAU'
-      }
-    })
+    pushStreams(app)
   })
 
-  it('uses empty field 10 when nextPoint has no name', (done) => {
-    // Route points typically have no name (just type: "RoutePoint" and a
-    // position). NMEA allows empty fields, so field 10 should be empty rather
-    // than a meaningless placeholder like "00".
-    const onEmit = (event, value) => {
-      const fields = parseApb(value)
-      assert.equal(
-        fields.waypointId,
-        '',
-        'field 10 should be empty when no waypoint name is available'
-      )
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, {
-      nextPoint: {
-        position: { latitude: 25.04133, longitude: -77.24333 },
-        type: 'RoutePoint'
-      }
-    })
-  })
-
-  it('computes correct XTE and steer direction from real data', (done) => {
-    // XTE = -39.84 m means vessel is left of track, steer Right.
-    // Magnitude in NM: 39.84 * 0.000539957 = 0.022 NM
+  it('computes correct XTE and steer direction', (done) => {
     const onEmit = (event, value) => {
       const fields = parseApb(value)
       assert.equal(fields.steerDirection, 'R', 'negative XTE = steer right')
@@ -142,63 +82,32 @@ describe('APB', function () {
       done()
     }
     const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, {})
+    pushStreams(app)
   })
 
-  it('computes bearings in degrees from radians', (done) => {
-    // bearingTrackTrue = 2.1503 rad = 123 deg
-    // bearingTrue = 2.1962 rad = 126 deg
-    // All three bearing pairs use True (fields 9, 12, 14 = 'T').
-    // Heading to steer (field 13) equals bearingTrue, not bearingMagnetic.
+  it('uses waypoint name from nextPoint', (done) => {
     const onEmit = (event, value) => {
       const fields = parseApb(value)
-      assert.equal(fields.bearingOriginToDest, '123')
-      assert.equal(fields.bearingPosToDest, '126')
-      assert.equal(fields.headingToSteer, '126')
+      assert.equal(fields.waypointId, 'NASSAU')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, {})
+    pushStreams(app, { nextPoint: { name: 'NASSAU' } })
   })
 
-  it('uses True reference for all three bearing pairs', (done) => {
-    // NMEA APB carries three bearing pairs (fields 8-9, 11-12, 13-14).
-    // All must use the same reference system. This plugin uses True for all
-    // three, which is correct for autopilots with a true heading source and
-    // matches the convention used by RMB in this repo.
+  it('wraps magnetic bearing near 360', (done) => {
+    // bearingTrue = 355 deg, variation = -10 deg (westerly)
+    // magnetic = 355 - (-10) = 365 -> wraps to 5 deg
     const onEmit = (event, value) => {
       const fields = parseApb(value)
-      assert.equal(fields.bearingOriginToDestRef, 'T', 'field 9')
-      assert.equal(fields.bearingPosToDestRef, 'T', 'field 12')
-      assert.equal(fields.headingToSteerRef, 'T', 'field 14')
+      assert.equal(fields.headingToSteer, '5')
       done()
     }
     const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, {})
-  })
-
-  it('steers Left when XTE is positive (vessel right of track)', (done) => {
-    const onEmit = (event, value) => {
-      const fields = parseApb(value)
-      assert.equal(fields.steerDirection, 'L', 'positive XTE = steer left')
-      assert.equal(fields.xteMagnitude, '0.054')
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'APB')
-    pushApbStreams(app, { crossTrackError: 100 })
-  })
-
-  it('does not subscribe to bearingMagnetic', () => {
-    const app = {
-      streambundle: { getSelfStream: () => ({ toProperty: () => ({}) }) },
-      emit: () => {},
-      debug: () => {}
-    }
-    const apb = require('../sentences/APB')(app)
-    assert.ok(
-      !apb.keys.includes('navigation.course.calcValues.bearingMagnetic'),
-      'APB should not subscribe to bearingMagnetic, got: ' +
-        JSON.stringify(apb.keys)
-    )
+    pushStreams(app, {
+      bearingTrackTrue: (350 * Math.PI) / 180,
+      bearingTrue: (355 * Math.PI) / 180,
+      magneticVariation: (-10 * Math.PI) / 180
+    })
   })
 })


### PR DESCRIPTION
## Summary

Restores backward compatibility for users with `"APB": true` in their config. #144 changed APB to all-True bearings, breaking legacy autopilots.

| Sentence | Bearings | Variation needed | For |
|---|---|---|---|
| **APB** (restored) | Magnetic (M) | Yes (subscribes to magneticVariation) | Raymarine SeaTalk 1, legacy autopilots |
| **APB-true** (new) | True (T) | No | pypilot, modern GPS autopilots |

Follows the HDM/HDMC, HDT/HDTC, DPT/DPT-surface pattern. No config options, no framework changes. Users enable the variant their autopilot needs.

Both always use consistent T/M references (never mixed), matching OpenCPN and the de facto industry standard.

## Test plan
- [x] `npm test` -- 86 tests pass
- [x] APB: all M, magnetic bearings computed from true + variation, wrap at 360
- [x] APB-true: all T, true bearings from Course API (existing tests renamed)