### PR TITLE
test: cover untested encoders, nmea helpers, and encoder metadata

### DIFF
--- a/test/metadata.js
+++ b/test/metadata.js
@@ -1,0 +1,341 @@
+const assert = require('assert')
+
+const stubApp = {}
+const load = (name) => require(`../sentences/${name}.js`)(stubApp)
+
+const expectations = [
+  {
+    name: 'APB',
+    sentence: 'APB',
+    title: 'APB - Autopilot info (magnetic bearings)',
+    keys: [
+      'navigation.course.calcValues.crossTrackError',
+      'navigation.course.calcValues.bearingTrackTrue',
+      'navigation.course.calcValues.bearingTrue',
+      'navigation.course.nextPoint',
+      'navigation.magneticVariation'
+    ]
+  },
+  {
+    name: 'APB-true',
+    sentence: 'APB',
+    title: 'APB - Autopilot info (true bearings)',
+    keys: [
+      'navigation.course.calcValues.crossTrackError',
+      'navigation.course.calcValues.bearingTrackTrue',
+      'navigation.course.calcValues.bearingTrue',
+      'navigation.course.nextPoint'
+    ]
+  },
+  {
+    name: 'DBK',
+    sentence: 'DBK',
+    title: 'DBK - Depth Below Keel',
+    keys: ['environment.depth.belowKeel']
+  },
+  {
+    name: 'DBS',
+    sentence: 'DBS',
+    title: 'DBS - Depth Below Surface',
+    keys: ['environment.depth.belowSurface']
+  },
+  {
+    name: 'DBT',
+    sentence: 'DBT',
+    title: 'DBT - Depth Below Transducer',
+    keys: ['environment.depth.belowTransducer']
+  },
+  {
+    name: 'DPT-surface',
+    sentence: 'DPT',
+    title: 'DPT - Depth at Surface (using surfaceToTransducer)',
+    keys: [
+      'environment.depth.belowTransducer',
+      'environment.depth.surfaceToTransducer'
+    ]
+  },
+  {
+    name: 'DPT',
+    sentence: 'DPT',
+    title: 'DPT - Depth',
+    keys: [
+      'environment.depth.belowTransducer',
+      'environment.depth.transducerToKeel'
+    ]
+  },
+  {
+    name: 'GGA',
+    sentence: 'GGA',
+    title: 'GGA - Time, position, and fix related data',
+    keys: [
+      'navigation.datetime',
+      'navigation.position',
+      'navigation.gnss.methodQuality',
+      'navigation.gnss.satellites',
+      'navigation.gnss.horizontalDilution',
+      'navigation.gnss.antennaAltitude',
+      'navigation.gnss.geoidalSeparation',
+      'navigation.gnss.differentialAge',
+      'navigation.gnss.differentialReference'
+    ]
+  },
+  {
+    name: 'GLL',
+    sentence: 'GLL',
+    title: 'GLL - Geographical position, latitude and longitude',
+    keys: ['navigation.datetime', 'navigation.position']
+  },
+  {
+    name: 'HDG',
+    sentence: 'HDG',
+    title: 'HDG - Heading, Deviation & Variation',
+    keys: ['navigation.headingMagnetic', 'navigation.magneticVariation']
+  },
+  {
+    name: 'HDM',
+    sentence: 'HDM',
+    title: 'HDM - Heading Magnetic',
+    keys: ['navigation.headingMagnetic']
+  },
+  {
+    name: 'HDMC',
+    sentence: 'HDM',
+    title: 'HDM - Heading Magnetic, calculated from True',
+    keys: ['navigation.headingTrue', 'navigation.magneticVariation']
+  },
+  {
+    name: 'HDT',
+    sentence: 'HDT',
+    title: 'HDT - Heading True',
+    keys: ['navigation.headingTrue']
+  },
+  {
+    name: 'HDTC',
+    sentence: 'HDTC',
+    title: 'HDT - Heading True calculated from magnetic heading and variation',
+    keys: ['navigation.headingMagnetic', 'navigation.magneticVariation']
+  },
+  {
+    name: 'MMB',
+    sentence: 'MMB',
+    title: 'MMB - Environment outside pressure',
+    keys: ['environment.outside.pressure']
+  },
+  {
+    name: 'MTA',
+    sentence: 'MTA',
+    title: 'MTA - Air temperature.',
+    keys: ['environment.outside.temperature']
+  },
+  {
+    name: 'MTW',
+    sentence: 'MTW',
+    title: 'MTW - Water Temperature',
+    keys: ['environment.water.temperature']
+  },
+  {
+    name: 'MWD',
+    sentence: 'MWD',
+    title: 'MWD - Wind relative to North, speed might be ground speed.',
+    keys: [
+      'environment.wind.directionTrue',
+      'navigation.magneticVariation',
+      'environment.wind.speedTrue'
+    ]
+  },
+  {
+    name: 'MWVR',
+    sentence: 'MWV',
+    title: 'MWV - Apparent Wind heading and speed',
+    keys: ['environment.wind.angleApparent', 'environment.wind.speedApparent']
+  },
+  {
+    name: 'MWVT',
+    sentence: 'MWV',
+    title: 'MWV - True Wind heading and speed',
+    keys: ['environment.wind.angleTrueWater', 'environment.wind.speedTrue']
+  },
+  {
+    name: 'PNKEP01',
+    title: 'PNKEP,01 - Target Polar speed',
+    keys: ['performance.polarSpeed']
+  },
+  {
+    name: 'PNKEP02',
+    title: 'PNKEP,02 - Course (COG) on other tack from 0 to 359°',
+    keys: ['performance.tackMagnetic']
+  },
+  {
+    name: 'PNKEP03',
+    title: 'PNKEP,03 - Polar and VMG, and optimum angle.',
+    keys: [
+      'performance.targetAngle',
+      'performance.polarVelocityMadeGoodRatio',
+      'performance.polarSpeedRatio'
+    ]
+  },
+  {
+    name: 'PNKEP99',
+    title: 'PNKEP,99 - Debug',
+    keys: [
+      'environment.wind.angleApparent',
+      'environment.wind.speedApparent',
+      'environment.wind.angleTrueWater',
+      'environment.wind.speedTrue',
+      'navigation.speedThroughWater',
+      'performance.polarSpeed',
+      'performance.polarSpeedRatio'
+    ]
+  },
+  {
+    name: 'PSILCD1',
+    title:
+      'PSILCD1 - Send polar speed and target wind angle to Silva/Nexus/Garmin displays',
+    keys: ['performance.polarSpeed', 'performance.targetAngle']
+  },
+  {
+    name: 'PSILTBS',
+    title: 'PSILTBS - Garmin proprietary target boat speed',
+    keys: ['performance.targetSpeed']
+  },
+  {
+    name: 'RMB',
+    sentence: 'RMB',
+    title: 'RMB - Heading and distance to waypoint',
+    keys: [
+      'navigation.course.calcValues.crossTrackError',
+      'navigation.course.nextPoint',
+      'navigation.course.calcValues.distance',
+      'navigation.course.calcValues.bearingTrue',
+      'navigation.course.calcValues.velocityMadeGood',
+      'navigation.course.previousPoint'
+    ]
+  },
+  {
+    name: 'RMC',
+    sentence: 'RMC',
+    title: 'RMC - GPS recommended minimum',
+    keys: [
+      'navigation.datetime',
+      'navigation.speedOverGround',
+      'navigation.courseOverGroundTrue',
+      'navigation.position',
+      'navigation.magneticVariation'
+    ]
+  },
+  {
+    name: 'ROT',
+    sentence: 'ROT',
+    title: 'ROT - Rate of Turn',
+    keys: ['navigation.rateOfTurn']
+  },
+  {
+    name: 'RSA',
+    sentence: 'RSA',
+    title: 'RSA - Rudder Sensor Angle',
+    keys: ['steering.rudderAngle']
+  },
+  {
+    name: 'VHW',
+    sentence: 'VHW',
+    title: 'VHW - Speed and direction',
+    keys: [
+      'navigation.headingTrue',
+      'navigation.magneticVariation',
+      'navigation.speedThroughWater'
+    ]
+  },
+  {
+    name: 'VLW',
+    sentence: 'VLW',
+    title: 'VLW - Total log and daily log',
+    keys: ['navigation.log', 'navigation.trip.log']
+  },
+  {
+    name: 'VPW',
+    sentence: 'VPW',
+    title: 'VPW - Speed – Measured Parallel to Wind',
+    keys: ['performance.velocityMadeGood']
+  },
+  {
+    name: 'VTG',
+    sentence: 'VTG',
+    title: 'VTG - Track made good and Ground Speed (COG,SOG)',
+    keys: [
+      'navigation.courseOverGroundMagnetic',
+      'navigation.courseOverGroundTrue',
+      'navigation.speedOverGround'
+    ]
+  },
+  {
+    name: 'VWR',
+    sentence: 'VWR',
+    title: 'VWR - Apparent wind angle and speed',
+    keys: ['environment.wind.speedApparent', 'environment.wind.angleApparent']
+  },
+  {
+    name: 'VWT',
+    sentence: 'VWT',
+    title: 'VWT - True wind speed relative to boat.',
+    keys: ['environment.wind.angleTrueWater', 'environment.wind.speedTrue']
+  },
+  {
+    name: 'XDRBaro',
+    title: 'XDR (Barometer) - Atmospheric Pressure',
+    keys: ['environment.outside.pressure']
+  },
+  {
+    name: 'XDRNA',
+    title: 'XDR (PTCH-ROLL) - Pitch and Roll',
+    keys: ['navigation.attitude']
+  },
+  {
+    name: 'XDRTemp',
+    title: 'XDR (TempAir) - Air temperature.',
+    keys: ['environment.outside.temperature']
+  },
+  {
+    name: 'XTE-GC',
+    title: 'XTE - Cross-track error (w.r.t. Great Circle)',
+    keys: ['navigation.courseGreatCircle.crossTrackError']
+  },
+  {
+    name: 'XTE',
+    title: 'XTE - Cross-track error (w.r.t. Rhumb line)',
+    keys: ['navigation.course.calcValues.crossTrackError']
+  },
+  {
+    name: 'ZDA',
+    title: 'ZDA - UTC time and date',
+    keys: ['navigation.datetime']
+  }
+]
+
+describe('sentence encoder metadata', function () {
+  expectations.forEach(({ name, sentence, title, keys }) => {
+    describe(name, function () {
+      const enc = load(name)
+      it('has the expected title', function () {
+        assert.equal(enc.title, title)
+      })
+      it('has the expected Signal K keys in the expected order', function () {
+        assert.deepStrictEqual(enc.keys, keys)
+      })
+      if (sentence !== undefined) {
+        it(`has sentence id '${sentence}'`, function () {
+          assert.equal(enc.sentence, sentence)
+        })
+      } else {
+        it('has no sentence id (pass-through module)', function () {
+          assert.strictEqual(enc.sentence, undefined)
+        })
+      }
+    })
+  })
+
+  describe('VWR exposes a legacy optionKey', function () {
+    it("optionKey is 'VWR'", function () {
+      assert.equal(load('VWR').optionKey, 'VWR')
+    })
+  })
+})

--- a/test/nmea.js
+++ b/test/nmea.js
@@ -2,7 +2,14 @@ const assert = require('assert')
 const {
   formatDatetime,
   toNmeaDegreesLatitude,
-  toNmeaDegreesLongitude
+  toNmeaDegreesLongitude,
+  toSentence,
+  radsToDeg,
+  msToKnots,
+  msToKM,
+  mToNm,
+  fixAngle,
+  radsToPositiveDeg
 } = require('../nmea.js')
 
 describe('nmea', function () {
@@ -235,6 +242,120 @@ describe('nmea', function () {
       assert.deepEqual(formatDatetime('not-a-date'), empty)
       assert.deepEqual(formatDatetime('hello world'), empty)
       assert.deepEqual(formatDatetime('2025-13-45T99:99:99Z'), empty)
+    })
+  })
+
+  describe('toSentence()', function () {
+    it('joins parts with comma and appends the XOR checksum', function () {
+      assert.equal(toSentence(['$IIHDT', '200.1', 'T']), '$IIHDT,200.1,T*21')
+    })
+
+    it('checksum is two uppercase hex digits prefixed with *', function () {
+      const result = toSentence(['$IIMWV', '180.00', 'R', '2.00', 'M', 'A'])
+      assert.equal(result, '$IIMWV,180.00,R,2.00,M,A*35')
+      assert.ok(/\*[0-9A-F]{2}$/.test(result))
+    })
+
+    it('checksum does not include the leading $', function () {
+      assert.equal(toSentence(['$IIHDM', '206.7', 'M']), '$IIHDM,206.7,M*21')
+    })
+  })
+
+  describe('radsToDeg()', function () {
+    it('converts 0 to 0', function () {
+      assert.equal(radsToDeg(0), 0)
+    })
+    it('converts PI to 180', function () {
+      assert.equal(radsToDeg(Math.PI), 180)
+    })
+    it('converts PI/2 to 90', function () {
+      assert.equal(radsToDeg(Math.PI / 2), 90)
+    })
+    it('converts negative radians to negative degrees', function () {
+      assert.equal(radsToDeg(-Math.PI), -180)
+    })
+    it('converts 2*PI to 360', function () {
+      assert.equal(radsToDeg(2 * Math.PI), 360)
+    })
+  })
+
+  describe('msToKnots()', function () {
+    it('converts 0 to 0', function () {
+      assert.equal(msToKnots(0), 0)
+    })
+    it('converts 1852/3600 m/s to 1 knot', function () {
+      assert.equal(Math.round(msToKnots(1852 / 3600) * 1e6) / 1e6, 1)
+    })
+    it('converts 1 m/s to ~1.94384 knots', function () {
+      assert.ok(Math.abs(msToKnots(1) - 1.9438444924) < 1e-6)
+    })
+    it('scales linearly with input', function () {
+      assert.ok(Math.abs(msToKnots(10) - 10 * msToKnots(1)) < 1e-9)
+    })
+  })
+
+  describe('msToKM()', function () {
+    it('converts 0 to 0', function () {
+      assert.equal(msToKM(0), 0)
+    })
+    it('converts 1 m/s to 3.6 km/h', function () {
+      assert.ok(Math.abs(msToKM(1) - 3.6) < 1e-9)
+    })
+    it('converts 10 m/s to 36 km/h', function () {
+      assert.ok(Math.abs(msToKM(10) - 36) < 1e-9)
+    })
+  })
+
+  describe('mToNm()', function () {
+    it('converts 0 to 0', function () {
+      assert.equal(mToNm(0), 0)
+    })
+    it('converts 1852 m to ~1 nm', function () {
+      assert.ok(Math.abs(mToNm(1852) - 1) < 1e-3)
+    })
+    it('converts 1 m to 0.000539957 nm', function () {
+      assert.equal(mToNm(1), 0.000539957)
+    })
+  })
+
+  describe('fixAngle()', function () {
+    it('returns input unchanged when in (-PI, PI]', function () {
+      assert.equal(fixAngle(0), 0)
+      assert.equal(fixAngle(1), 1)
+      assert.equal(fixAngle(-1), -1)
+      assert.equal(fixAngle(Math.PI), Math.PI)
+    })
+    it('subtracts 2*PI when > PI', function () {
+      const result = fixAngle(Math.PI + 0.5)
+      assert.ok(Math.abs(result - (0.5 - Math.PI)) < 1e-9)
+    })
+    it('adds 2*PI when < -PI', function () {
+      const result = fixAngle(-Math.PI - 0.5)
+      assert.ok(Math.abs(result - (Math.PI - 0.5)) < 1e-9)
+    })
+    it('leaves -PI unchanged (lower bound is strict)', function () {
+      assert.equal(fixAngle(-Math.PI), -Math.PI)
+    })
+    it('leaves PI unchanged (upper bound is strict)', function () {
+      assert.equal(fixAngle(Math.PI), Math.PI)
+    })
+  })
+
+  describe('radsToPositiveDeg()', function () {
+    it('maps 0 to 0', function () {
+      assert.equal(radsToPositiveDeg(0), 0)
+    })
+    it('maps PI to 180', function () {
+      assert.equal(radsToPositiveDeg(Math.PI), 180)
+    })
+    it('maps -PI/2 to 270', function () {
+      assert.equal(radsToPositiveDeg(-Math.PI / 2), 270)
+    })
+    it('maps -PI to 180', function () {
+      assert.equal(radsToPositiveDeg(-Math.PI), 180)
+    })
+    it('keeps positives unchanged below 2*PI', function () {
+      assert.ok(Math.abs(radsToPositiveDeg(Math.PI / 4) - 45) < 1e-9)
     })
   })
 })

--- a/test/sentences.js
+++ b/test/sentences.js
@@ -1,0 +1,287 @@
+const assert = require('assert')
+
+const stubApp = { debug: () => {}, error: () => {}, emit: () => {} }
+const load = (name) => require(`../sentences/${name}.js`)(stubApp)
+
+function expectedChecksum(body) {
+  let c = 0
+  for (let i = 0; i < body.length; i++) c ^= body.charCodeAt(i)
+  return '*' + c.toString(16).toUpperCase().padStart(2, '0')
+}
+
+function assertValidSentence(sentence) {
+  const m = /^\$([^*]+)\*([0-9A-F]{2})$/.exec(sentence)
+  assert.ok(m, `not a well-formed NMEA sentence: ${sentence}`)
+  assert.equal(
+    '*' + m[2],
+    expectedChecksum(m[1]),
+    `bad checksum in ${sentence}`
+  )
+}
+
+describe('sentence encoders', function () {
+  describe('DBK - Depth Below Keel', function () {
+    it('encodes at 31.38 m', function () {
+      const s = load('DBK').f(31.38)
+      assert.ok(s.startsWith('$IIDBK,103.0,f,31.38,M,17.2,F*'))
+      assertValidSentence(s)
+    })
+    it('encodes 0', function () {
+      const s = load('DBK').f(0)
+      assert.ok(s.startsWith('$IIDBK,0.0,f,0.00,M,0.0,F*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('DBS - Depth Below Surface', function () {
+    it('encodes at 31.38 m', function () {
+      const s = load('DBS').f(31.38)
+      assert.ok(s.startsWith('$IIDBS,103.0,f,31.38,M,17.2,F*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('DPT (transducer to keel)', function () {
+    it('forces the offset to negative regardless of input sign', function () {
+      const s = load('DPT').f(10.5, 0.75)
+      assert.ok(s.startsWith('$IIDPT,10.50,-0.750*'))
+      assertValidSentence(s)
+    })
+    it('keeps the offset negative when input is already negative', function () {
+      const s = load('DPT').f(10.5, -0.75)
+      assert.ok(s.startsWith('$IIDPT,10.50,-0.750*'))
+    })
+  })
+
+  describe('DPT-surface (surface to transducer)', function () {
+    it('preserves a positive offset', function () {
+      const s = load('DPT-surface').f(9.21, 1.1)
+      assert.ok(s.startsWith('$IIDPT,9.21,1.100*'))
+      assertValidSentence(s)
+    })
+    it('preserves a negative offset', function () {
+      const s = load('DPT-surface').f(5, -0.2)
+      assert.ok(s.startsWith('$IIDPT,5.00,-0.200*'))
+    })
+  })
+
+  describe('HDT - heading true', function () {
+    it('emits heading normalised to [0, 360) with 1 decimal', function () {
+      const s = load('HDT').f(Math.PI)
+      assert.ok(s.startsWith('$IIHDT,180.0,T*'))
+      assertValidSentence(s)
+    })
+    it('wraps negative heading into [0, 360)', function () {
+      const s = load('HDT').f(-Math.PI / 2)
+      assert.ok(s.startsWith('$IIHDT,270.0,T*'))
+    })
+  })
+
+  describe('HDTC - true heading from magnetic + variation', function () {
+    it('sums magnetic and variation', function () {
+      const s = load('HDTC').f(Math.PI / 2, 0.1)
+      assert.ok(s.startsWith('$IIHDT,95.7,T*'))
+      assertValidSentence(s)
+    })
+    it('wraps when sum is negative', function () {
+      const s = load('HDTC').f(0.1, -0.3)
+      assert.ok(s.startsWith('$IIHDT,348.5,T*'))
+    })
+  })
+
+  describe('MTW - water temperature (K to C)', function () {
+    it('converts K to C with 1 decimal', function () {
+      const s = load('MTW').f(293.15)
+      assert.ok(s.startsWith('$IIMTW,20.0,C*'))
+      assertValidSentence(s)
+    })
+    it('converts 273.15 K to 0 C', function () {
+      const s = load('MTW').f(273.15)
+      assert.ok(s.startsWith('$IIMTW,0.0,C*'))
+    })
+  })
+
+  describe('MTA - air temperature (K to C)', function () {
+    it('converts K to C with 2 decimals', function () {
+      const s = load('MTA').f(308.0)
+      assert.ok(s.startsWith('$IIMTA,34.85,C*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('MMB - barometric pressure', function () {
+    it('encodes pressure in inHg and bar', function () {
+      const s = load('MMB').f(100000)
+      assert.ok(s.startsWith('$IIMMB,29.5300,I,1.0000,B*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('ROT - rate of turn', function () {
+    it('converts rad/s to deg/min', function () {
+      const s = load('ROT').f(1)
+      assert.ok(s.startsWith('$IIROT,3437.75,A*'))
+      assertValidSentence(s)
+    })
+    it('handles a negative rate', function () {
+      const s = load('ROT').f(-0.01)
+      assert.ok(s.startsWith('$IIROT,-34.38,A*'))
+    })
+  })
+
+  describe('RSA - rudder sensor angle', function () {
+    it('converts the rudder angle from rad to deg', function () {
+      const s = load('RSA').f(Math.PI / 4)
+      assert.ok(s.startsWith('$IIRSA,45.00,A,,*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('VLW - total and trip log', function () {
+    it('encodes log and trip distances in nautical miles', function () {
+      const s = load('VLW').f(1852, 80000)
+      assert.ok(s.startsWith('$IIVLW,1.00,N,43.20,N*'))
+      assertValidSentence(s)
+    })
+    it('encodes zero distances', function () {
+      const s = load('VLW').f(0, 0)
+      assert.ok(s.startsWith('$IIVLW,0.00,N,0.00,N*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('VPW - speed parallel to wind', function () {
+    it('encodes VMG in knots and m/s', function () {
+      const s = load('VPW').f(5)
+      assert.ok(s.startsWith('$IIVPW,9.72,N,5.00,M*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('VWR - apparent wind angle + speed', function () {
+    const enc = load('VWR')
+    it('emits R for starboard (positive angle)', function () {
+      const s = enc.f(1, 0.5)
+      assert.ok(s.startsWith('$IIVWR,28.65,R,1.94,N,1.00,M,3.60,K*'))
+      assertValidSentence(s)
+    })
+    it('emits L and abs(angle) for port (negative angle)', function () {
+      const s = enc.f(1, -0.5)
+      assert.ok(s.startsWith('$IIVWR,28.65,L,1.94,N,1.00,M,3.60,K*'))
+    })
+    it('emits R when angle is exactly 0', function () {
+      const s = enc.f(5, 0)
+      assert.ok(s.startsWith('$IIVWR,0.00,R,'))
+    })
+  })
+
+  describe('XDR (Barometer)', function () {
+    it('emits $IIXDR,P,<bar>,B,Barometer', function () {
+      const s = load('XDRBaro').f(102481)
+      assert.ok(s.startsWith('$IIXDR,P,1.0248,B,Barometer*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('XDR (TempAir)', function () {
+    it('emits $IIXDR,C,<celsius>,C,TempAir', function () {
+      const s = load('XDRTemp').f(307.95)
+      assert.ok(s.startsWith('$IIXDR,C,34.80,C,TempAir*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('XDR (PTCH/ROLL)', function () {
+    it('emits pitch and roll in degrees', function () {
+      const s = load('XDRNA').f({ pitch: -0.012, roll: 0.016 })
+      assert.ok(s.startsWith('$IIXDR,A,-0.7,D,PTCH,A,0.9,D,ROLL*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('XTE - cross-track error (rhumb line)', function () {
+    const enc = load('XTE')
+    it('emits L when xte is positive (value is absolute)', function () {
+      const s = enc.f(100)
+      assert.ok(s.startsWith('$IIXTE,A,A,0.054,L,N*'))
+      assertValidSentence(s)
+    })
+    it('emits R when xte is negative (value is absolute)', function () {
+      const s = enc.f(-100)
+      assert.ok(s.startsWith('$IIXTE,A,A,0.054,R,N*'))
+    })
+    it('emits L when xte is exactly 0', function () {
+      const s = enc.f(0)
+      assert.ok(s.includes(',0.000,L,'))
+    })
+  })
+
+  describe('XTE-GC - cross-track error (great circle)', function () {
+    const enc = load('XTE-GC')
+    it('emits L when xte is positive', function () {
+      const s = enc.f(100)
+      assert.ok(s.startsWith('$IIXTE,A,A,0.054,L,N*'))
+      assertValidSentence(s)
+    })
+    it('emits R when xte is negative', function () {
+      const s = enc.f(-100)
+      assert.ok(s.startsWith('$IIXTE,A,A,0.054,R,N*'))
+    })
+    it('emits L when xte is exactly 0', function () {
+      const s = enc.f(0)
+      assert.ok(s.includes(',0.000,L,'))
+    })
+  })
+
+  describe('PNKEP01 - target polar speed', function () {
+    it('encodes target speed in knots and km/h', function () {
+      const s = load('PNKEP01').f(5)
+      assert.ok(s.startsWith('$PNKEP,01,9.72,N,18.00,K*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('PNKEP02 - COG on other tack', function () {
+    it('encodes angle normalised to [0, 360)', function () {
+      const s = load('PNKEP02').f(Math.PI)
+      assert.ok(s.startsWith('$PNKEP,02,180.00*'))
+      assertValidSentence(s)
+    })
+    it('wraps negative angle into [0, 360)', function () {
+      const s = load('PNKEP02').f(-Math.PI / 2)
+      assert.ok(s.startsWith('$PNKEP,02,270.00*'))
+    })
+  })
+
+  describe('PNKEP03 - polar/VMG/optimum angle', function () {
+    it('encodes angle and ratios as percentages', function () {
+      const s = load('PNKEP03').f(Math.PI / 4, 0.9, 0.85)
+      assert.ok(s.startsWith('$PNKEP,03,45.00,90.00,85.00*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('PNKEP99 - debug', function () {
+    it('emits debug sentence with raw conversions', function () {
+      const s = load('PNKEP99').f(0, 0, 0, 0, 0, 0, 0)
+      assert.ok(s.startsWith('$PNKEP,99,0,0,0,0,0,0,0*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('PSILCD1 - polar speed + target wind angle', function () {
+    it('encodes in knots and degrees', function () {
+      const s = load('PSILCD1').f(5, Math.PI / 4)
+      assert.ok(s.startsWith('$PSILCD1,9.72,45.00*'))
+      assertValidSentence(s)
+    })
+  })
+
+  describe('PSILTBS - target boat speed', function () {
+    it('encodes in knots', function () {
+      const s = load('PSILTBS').f(5)
+      assert.ok(s.startsWith('$PSILTBS,9.72,N*'))
+      assertValidSentence(s)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Rebased onto current master. Adds coverage in three areas:

- **Untested sentence encoders**: tests for the 22 encoders that had no coverage — DBK, DBS, DPT, DPT-surface, HDT, HDTC, MMB, MTA, MTW, ROT, RSA, VLW, VPW, VWR, XDRBaro, XDRNA, XDRTemp, XTE, XTE-GC, PNKEP01/02/03/99, PSILCD1, PSILTBS. Each calls the encoder's \`f()\` directly and verifies the NMEA checksum by recomputing the XOR.
- **Missing \`nmea.js\` helper cases**: \`toSentence\`, \`radsToDeg\`, \`msToKnots\`, \`msToKM\`, \`mToNm\`, \`fixAngle\`, and \`radsToPositiveDeg\` (upstream only tested \`toNmeaDegrees*\` and \`formatDatetime\`).
- **Encoder metadata pinning**: new \`test/metadata.js\` asserts \`title\`, \`sentence\`, and the full Signal K \`keys\` array for every encoder so typos or accidental path renames fail CI.

## Test plan
- [x] \`npm test\` — 281 passing (was 86)
- [x] \`npx prettier --check test/\` clean