### PR TITLE
chore: bump typescript 5.9 -> 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "prettier": "^3.8.2",
         "rimraf": "^6.1.3",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"
@@ -3934,9 +3934,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prettier": "^3.8.2",
     "rimraf": "^6.1.3",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "c8": {
     "extension": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,10 @@
     // churn for a plugin that will always be CJS on the host side.
     "module": "commonjs",
     "moduleResolution": "node",
+    // TS 6 turned the legacy `node` (a.k.a. node10) moduleResolution into a
+    // hard deprecation. Silence that so the package can stay on `node` for
+    // now; migrating to `node16` / `bundler` is a separate audit.
+    "ignoreDeprecations": "6.0",
     "lib": ["ES2022"],
 
     "strict": true,
@@ -27,6 +31,9 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    // TS 6 tightened the default @types scan: mocha's describe / it globals
+    // no longer leak in unless the test runner is listed here explicitly.
+    "types": ["node", "mocha"],
 
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary

Aligns with the rest of the SignalK plugin family on typescript `^6.0.3`.

tsconfig additions:
- `ignoreDeprecations: "6.0"` — silences the TS 6 hard deprecation of the legacy `node` moduleResolution. Migrating to `node16` / `bundler` is a separate audit.
- `types: ["node", "mocha"]` — TS 6 tightened the default @types scan; mocha's `describe` / `it` globals no longer leak in automatically.

No source changes required.

## Test plan

- [x] npm run typecheck clean
- [x] npm run build clean
- [x] npm test 283 passing
- [x] npm run prettier:check clean
- [ ] CI green on Node 22 + Node 24 with both baconjs versions