### PR TITLE
refactor: use @signalk/server-api types for plugin/app/Position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.16.1",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@signalk/server-api": "^2.24.0",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/mocha-runner": "^9.6.1",
         "@types/mocha": "^10.0.10",
@@ -1430,6 +1431,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1445,6 +1459,25 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@signalk/server-api": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@signalk/server-api/-/server-api-2.24.0.tgz",
+      "integrity": "sha512-IZWVIuV/vOG4obKZ7vhUCfZ19XhpmXlUq8MNV9G10S6vF2vBKZ6JiOaYVVAyzbihlzPafD4Mq7wGurvWur1a0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
+        "@sinclair/typebox": "^0.34.0",
+        "baconjs": "^3.0.0"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -2774,6 +2807,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "author": "teppo.kurki@iki.fi",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@signalk/server-api": "^2.24.0",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/mocha-runner": "^9.6.1",
     "@types/mocha": "^10.0.10",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
  */
 import { sentenceFactories } from './sentences'
 import type * as PluginTypes from './types/plugin'
+import type { Path } from '@signalk/server-api'
 import type { Property } from 'baconjs'
 
 type AnyStream<T = unknown> = PluginTypes.AnyStream<T>
@@ -61,7 +62,7 @@ const createPlugin = function (app: SignalKApp): SignalKPlugin {
     start: function (options: Record<string, unknown>): void {
       function mapToNmea(encoder: SentenceEncoder, throttle?: unknown): void {
         const selfStreams = encoder.keys.map((key, index) => {
-          let stream: AnyStream = app.streambundle.getSelfStream(key)
+          let stream: AnyStream = app.streambundle.getSelfStream(key as Path)
           if (
             encoder.defaults &&
             typeof encoder.defaults[index] !== 'undefined'

--- a/src/sentences/GGA.ts
+++ b/src/sentences/GGA.ts
@@ -29,12 +29,8 @@ import {
   toNmeaDegreesLongitude,
   formatDatetime
 } from '../nmea'
+import type { Position } from '@signalk/server-api'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
-
-interface Position {
-  latitude: number
-  longitude: number
-}
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {

--- a/src/sentences/GLL.ts
+++ b/src/sentences/GLL.ts
@@ -10,12 +10,8 @@ Example: $GPGLL,5943.4970,N,02444.1983,E,200001.00,A*03
 */
 
 import * as nmea from '../nmea'
+import type { Position } from '@signalk/server-api'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
-
-interface Position {
-  latitude: number
-  longitude: number
-}
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {

--- a/src/sentences/RMC.ts
+++ b/src/sentences/RMC.ts
@@ -31,12 +31,8 @@ import {
   msToKnots,
   formatDatetime
 } from '../nmea'
+import type { Position } from '@signalk/server-api'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
-
-interface Position {
-  latitude: number
-  longitude: number
-}
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,11 +1,10 @@
 /**
  * Core types for the signalk-to-nmea0183 plugin.
  *
- * `SignalKApp` is a minimal structural description of the `app` argument
- * the signalk-server host passes to the plugin factory. Only the members
- * the plugin actually uses are modelled. `unknown` is preferred over `any`
- * so that downstream calls go through explicit narrowing or a cast, which
- * keeps accidental misuse visible at the call site.
+ * `SignalKApp` extends the public `ServerAPI` from `@signalk/server-api`
+ * with the `emit` method the plugin uses to publish NMEA0183 sentences
+ * on the host's event bus. `emit` is part of the `EventEmitter` the
+ * server inherits from but is not modelled in `@signalk/server-api`.
  *
  * `SentenceEncoder` is the shape every module in src/sentences/ returns.
  * Keys are Signal K paths; `f` is invoked with the latest value for each
@@ -17,28 +16,21 @@
  * must emit at least once before the combined stream fires.
  */
 import type { EventStream, Property } from 'baconjs'
+import type { Plugin, ServerAPI } from '@signalk/server-api'
+
+export type { StreamBundle } from '@signalk/server-api'
 
 /** @internal */
 export type AnyStream<T = unknown> = EventStream<T> | Property<T>
 
-// `StreamBundle` is exposed because `SignalKApp.streambundle` references
-// it; stripping it via @internal would leave the public `.d.ts`
-// referring to a symbol that no longer exists.
-export interface StreamBundle {
-  getSelfStream: (path: string) => AnyStream
-}
-
 /**
- * Minimal structural type for the `app` object the signalk-server host
- * passes to the plugin factory. Only the members this plugin actually
- * reaches for are modelled.
+ * Extends the public `ServerAPI` with the EventEmitter `emit` method
+ * the plugin uses to publish NMEA0183 sentences on the host's event
+ * bus. The server is an EventEmitter at runtime but `emit` is not part
+ * of the typed surface in `@signalk/server-api`.
  */
-export interface SignalKApp {
-  streambundle: StreamBundle
-  emit: (event: string, value: unknown) => void
-  debug: (msg: unknown) => void
-  error?: (msg: unknown) => void
-  reportOutputMessages?: (n: number) => void
+export interface SignalKApp extends ServerAPI {
+  emit(event: string, value: unknown): void
 }
 
 /**
@@ -92,13 +84,8 @@ export interface SignalKPluginSchema {
  * Consumers normally don't construct this directly — they call the
  * factory exported by the package entry.
  */
-export interface SignalKPlugin {
-  id: string
-  name: string
-  description: string
+export interface SignalKPlugin extends Plugin {
   schema: SignalKPluginSchema
-  start: (options: Record<string, unknown>) => void
-  stop: () => void
   sentences: Record<string, SentenceEncoder>
   unsubscribes: Array<() => void>
 }


### PR DESCRIPTION
## Summary

Replace local `SignalKApp`, `SignalKPlugin`, `StreamBundle`, and `Position` interfaces with the canonical types from `@signalk/server-api`.

- `SignalKApp` now extends `ServerAPI`, adding only the EventEmitter `emit` method (used to publish NMEA0183 sentences on the host's event bus). `emit` is part of the underlying server class but is not modelled in `@signalk/server-api`.
- `SignalKPlugin` now extends `Plugin`, narrowing `schema` to `SignalKPluginSchema` and adding the plugin-specific `sentences` and `unsubscribes` fields.
- `StreamBundle` is re-exported from `@signalk/server-api` instead of being declared locally.
- The local `interface Position` in GGA, GLL, and RMC encoders is dropped in favour of `Position` from `@signalk/server-api`.

The local interfaces were a partial restatement of types already exported by the server-api package. Using the canonical types removes the duplication and means future additions to the server API are picked up automatically.

`@signalk/server-api` is added as a `devDependency` (types-only consumption; runtime instances come from the host server).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` passes (283 tests)
- [x] `npm run prettier:check` passes