### PR TITLE
fix(BWC): use canonical navigation.course.nextPoint and activeRoute

### DIFF
--- a/src/sentences/BWC.ts
+++ b/src/sentences/BWC.ts
@@ -1,5 +1,5 @@
 /*
-Bearing and Distance to Waypoint (Great Circle):
+Bearing and Distance to Waypoint:
                                                           12  13
      1       2       3 4        5 6         7 8    9 10 11|   |
      |       |       | |        | |         | |    | |  | |   |
@@ -23,27 +23,51 @@ Field Number:
 Signal K source paths verified by subscribing to the live deltastream of a
 running signalk-server (openplotter) with an active route:
 
-  - navigation.datetime                              -> ISO datetime
-  - navigation.courseGreatCircle.nextPoint.position  -> {latitude, longitude}
-  - navigation.course.calcValues.bearingTrue         -> bearing to waypoint, true (rad)
-  - navigation.course.calcValues.bearingMagnetic     -> bearing to waypoint, magnetic (rad, optional)
-  - navigation.course.calcValues.distance            -> distance to waypoint (m)
+  - navigation.datetime                            -> ISO datetime
+  - navigation.course.nextPoint                    -> {type, position, [name]}
+  - navigation.course.activeRoute                  -> {href, name, pointIndex, pointTotal}
+  - navigation.course.calcValues.bearingTrue       -> bearing to waypoint (rad)
+  - navigation.course.calcValues.bearingMagnetic   -> bearing to waypoint, magnetic (rad, optional)
+  - navigation.course.calcValues.distance          -> distance to waypoint (m)
 
-NB: the parent path 'navigation.courseGreatCircle.nextPoint' is silent on the
-deltastream (signalk-server only publishes its leaf children), so subscribe
-to '.position' directly. Waypoint name (field 12) currently has no published
-delta source; left empty until SignalK/signalk-server#2595 lands.
+`navigation.course.nextPoint` is the canonical waypoint path: it is published
+as a composite delta containing both `type` (RoutePoint / Location /
+VesselPosition) and `position` regardless of the active calculation method.
+The parallel `navigation.courseGreatCircle.nextPoint` is silent on the
+deltastream (only its leaf children emit) and is NOT what to subscribe to.
 
-The course-provider publishes calcValues with calcMethod="GreatCircle", so the
-'course' namespace carries the great-circle values that BWC requires.
+Waypoint name resolution (field 12):
+  1. nextPoint.name when SignalK/signalk-server#2595 lands
+  2. activeRoute.name with /pointIndex when a multi-point route is active
+  3. activeRoute.name alone for a single-point route
+  4. empty when the destination is a Location-type point with no route
+
+Bearing values reflect the calcMethod set in signalk-server (GreatCircle or
+Rhumbline). For typical sailing distances the difference is negligible; if
+you need strictly great-circle BWC, set the server's course calc method to
+GreatCircle.
 */
 import * as nmea from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
 
-interface Position {
-  latitude?: number
-  longitude?: number
+interface NextPoint {
+  type?: string
+  position?: { latitude?: number; longitude?: number }
+  name?: string
 }
+
+interface ActiveRoute {
+  href?: string | null
+  name?: string | null
+  pointIndex?: number | null
+  pointTotal?: number | null
+}
+
+// NMEA0183 reserves these characters for sentence framing. A waypoint name
+// containing them would inject fields, forge a checksum boundary, or break
+// out of the sentence entirely.
+const NMEA_RESERVED = /[,*$\r\n]/g
+const MAX_WAYPOINT_ID_LEN = 20
 
 function inLatRange(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v) && v >= -90 && v <= 90
@@ -56,26 +80,50 @@ function inLonRange(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v) && v > -180 && v <= 180
 }
 
+function deriveWaypointId(
+  nextPoint: NextPoint,
+  activeRoute: ActiveRoute
+): string {
+  // Prefer the per-waypoint name once SignalK publishes it.
+  if (typeof nextPoint.name === 'string' && nextPoint.name.length > 0) {
+    return nextPoint.name
+  }
+  // Fall back to the active route's name. Append the 1-based point index
+  // when the route has more than one point so successive BWCs are distinct.
+  if (typeof activeRoute.name === 'string' && activeRoute.name.length > 0) {
+    if (
+      typeof activeRoute.pointIndex === 'number' &&
+      typeof activeRoute.pointTotal === 'number' &&
+      activeRoute.pointTotal > 1
+    ) {
+      return `${activeRoute.name}/${activeRoute.pointIndex + 1}`
+    }
+    return activeRoute.name
+  }
+  return ''
+}
+
 export default function (_app: SignalKApp): SentenceEncoder {
   return {
     sentence: 'BWC',
     title: 'BWC - Bearing and distance to waypoint',
     keys: [
       'navigation.datetime',
-      'navigation.courseGreatCircle.nextPoint.position',
+      'navigation.course.nextPoint',
+      'navigation.course.activeRoute',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.calcValues.bearingMagnetic',
       'navigation.course.calcValues.distance'
     ],
-    // bearingMagnetic seeds with null so the combined stream fires even when
-    // the server has not yet published it (older servers, or before the first
-    // recompute). The encoder treats a non-finite value as "magnetic unknown"
-    // and emits empty fields 8 and 9 per NMEA0183 convention.
-    // All other inputs are required (undefined default = wait for first delta).
-    defaults: ['', undefined, undefined, null, undefined],
+    // activeRoute defaults to {} so a Location-type destination (no route)
+    // still emits; bearingMagnetic seeds with null so older servers that
+    // don't publish it still let the combined stream fire (encoder emits
+    // empty fields 8/9 when magnetic is missing).
+    defaults: ['', undefined, {}, undefined, null, undefined],
     f: function (
       datetime8601: string,
-      position: Position | null | undefined,
+      nextPoint: NextPoint | null | undefined,
+      activeRoute: ActiveRoute | null | undefined,
       bearingTrue: number | undefined,
       bearingMagnetic: number | null | undefined,
       distance: number | undefined
@@ -86,8 +134,13 @@ export default function (_app: SignalKApp): SentenceEncoder {
         return undefined
       }
 
-      const wpLat = position?.latitude
-      const wpLon = position?.longitude
+      if (nextPoint == null) {
+        _app.debug('BWC: skipping emission - nextPoint is null')
+        return undefined
+      }
+
+      const wpLat = nextPoint.position?.latitude
+      const wpLon = nextPoint.position?.longitude
 
       if (
         !inLatRange(wpLat) ||
@@ -107,6 +160,14 @@ export default function (_app: SignalKApp): SentenceEncoder {
         ? nmea.radsToPositiveDeg(bearingMagnetic as number)
         : undefined
 
+      const rawId = deriveWaypointId(nextPoint, activeRoute ?? {})
+      const sanitized = rawId.replace(NMEA_RESERVED, '')
+      let waypointId = sanitized
+      if (waypointId.length > MAX_WAYPOINT_ID_LEN) {
+        waypointId = waypointId.slice(0, MAX_WAYPOINT_ID_LEN)
+        _app.debug('BWC: truncated waypoint name to 20 characters')
+      }
+
       return nmea.toSentence([
         '$IIBWC',
         datetime.time,
@@ -118,7 +179,7 @@ export default function (_app: SignalKApp): SentenceEncoder {
         bearingMagneticDeg !== undefined ? 'M' : '',
         nmea.mToNm(distance as number).toFixed(2),
         'N',
-        '' // waypoint name has no live delta source today; see file header
+        waypointId
       ])
     }
   }

--- a/src/sentences/BWC.ts
+++ b/src/sentences/BWC.ts
@@ -20,29 +20,30 @@ Field Number:
 12. Waypoint ID
 13. Checksum
 
-Signal K source paths verified against signalk-server's CourseApi:
-  - navigation.courseGreatCircle.nextPoint     -> waypoint position (and future name)
-  - navigation.course.calcValues.bearingTrue   -> bearing to waypoint, true (rad)
-  - navigation.course.calcValues.bearingMagnetic -> bearing to waypoint, magnetic (rad, optional)
-  - navigation.course.calcValues.distance      -> distance to waypoint (m)
+Signal K source paths verified by subscribing to the live deltastream of a
+running signalk-server (openplotter) with an active route:
+
+  - navigation.datetime                              -> ISO datetime
+  - navigation.courseGreatCircle.nextPoint.position  -> {latitude, longitude}
+  - navigation.course.calcValues.bearingTrue         -> bearing to waypoint, true (rad)
+  - navigation.course.calcValues.bearingMagnetic     -> bearing to waypoint, magnetic (rad, optional)
+  - navigation.course.calcValues.distance            -> distance to waypoint (m)
+
+NB: the parent path 'navigation.courseGreatCircle.nextPoint' is silent on the
+deltastream (signalk-server only publishes its leaf children), so subscribe
+to '.position' directly. Waypoint name (field 12) currently has no published
+delta source; left empty until SignalK/signalk-server#2595 lands.
 
 The course-provider publishes calcValues with calcMethod="GreatCircle", so the
-'course' namespace carries the great-circle values that BWC requires; the
-'courseGreatCircle' namespace only carries activeRoute / nextPoint / previousPoint.
+'course' namespace carries the great-circle values that BWC requires.
 */
 import * as nmea from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
 
-interface NextPoint {
-  position?: { latitude?: number; longitude?: number }
-  name?: string
+interface Position {
+  latitude?: number
+  longitude?: number
 }
-
-// NMEA0183 reserves these characters for sentence framing. A waypoint name
-// containing them would inject fields, forge a checksum boundary, or break
-// out of the sentence entirely.
-const NMEA_RESERVED = /[,*$\r\n]/g
-const MAX_WAYPOINT_ID_LEN = 20
 
 function inLatRange(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v) && v >= -90 && v <= 90
@@ -61,20 +62,22 @@ export default function (_app: SignalKApp): SentenceEncoder {
     title: 'BWC - Bearing and distance to waypoint',
     keys: [
       'navigation.datetime',
-      'navigation.courseGreatCircle.nextPoint',
+      'navigation.courseGreatCircle.nextPoint.position',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.calcValues.bearingMagnetic',
       'navigation.course.calcValues.distance'
     ],
-    // bearingMagnetic defaults to undefined: when the server does not publish
-    // it, fields 8 and 9 are emitted empty per NMEA0183 "value unknown" convention.
-    // All other inputs are required.
-    defaults: ['', undefined, undefined, undefined, undefined],
+    // bearingMagnetic seeds with null so the combined stream fires even when
+    // the server has not yet published it (older servers, or before the first
+    // recompute). The encoder treats a non-finite value as "magnetic unknown"
+    // and emits empty fields 8 and 9 per NMEA0183 convention.
+    // All other inputs are required (undefined default = wait for first delta).
+    defaults: ['', undefined, undefined, null, undefined],
     f: function (
       datetime8601: string,
-      nextPoint: NextPoint | null | undefined,
+      position: Position | null | undefined,
       bearingTrue: number | undefined,
-      bearingMagnetic: number | undefined,
+      bearingMagnetic: number | null | undefined,
       distance: number | undefined
     ): string | undefined {
       const datetime = nmea.formatDatetime(datetime8601)
@@ -83,13 +86,8 @@ export default function (_app: SignalKApp): SentenceEncoder {
         return undefined
       }
 
-      if (nextPoint == null) {
-        _app.debug('BWC: skipping emission - nextPoint is null')
-        return undefined
-      }
-
-      const wpLat = nextPoint.position?.latitude
-      const wpLon = nextPoint.position?.longitude
+      const wpLat = position?.latitude
+      const wpLon = position?.longitude
 
       if (
         !inLatRange(wpLat) ||
@@ -109,14 +107,6 @@ export default function (_app: SignalKApp): SentenceEncoder {
         ? nmea.radsToPositiveDeg(bearingMagnetic as number)
         : undefined
 
-      const rawName = typeof nextPoint.name === 'string' ? nextPoint.name : ''
-      const sanitized = rawName.replace(NMEA_RESERVED, '')
-      let waypointId = sanitized
-      if (waypointId.length > MAX_WAYPOINT_ID_LEN) {
-        waypointId = waypointId.slice(0, MAX_WAYPOINT_ID_LEN)
-        _app.debug('BWC: truncated waypoint name to 20 characters')
-      }
-
       return nmea.toSentence([
         '$IIBWC',
         datetime.time,
@@ -128,7 +118,7 @@ export default function (_app: SignalKApp): SentenceEncoder {
         bearingMagneticDeg !== undefined ? 'M' : '',
         nmea.mToNm(distance as number).toFixed(2),
         'N',
-        waypointId
+        '' // waypoint name has no live delta source today; see file header
       ])
     }
   }

--- a/test/BWC-integration.ts
+++ b/test/BWC-integration.ts
@@ -9,7 +9,7 @@ import type { SignalKPlugin } from '../src/types/plugin'
 
 // Live snapshot from openplotter (vessel sailing near Marsh Harbour,
 // Bahamas, 9° W magnetic variation, route active with a Location-type
-// destination so nextPoint has no name field).
+// destination so the waypoint name has no published delta source).
 const LIVE_SNAPSHOT = {
   datetime: '2026-05-08T16:38:51.000Z',
   position: { latitude: 26.547522602871112, longitude: -77.0623540878296 },
@@ -57,7 +57,7 @@ describe('BWC Integration', function () {
 
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
-      { position: LIVE_SNAPSHOT.position },
+      LIVE_SNAPSHOT.position,
       LIVE_SNAPSHOT.bearingTrue,
       LIVE_SNAPSHOT.bearingMagnetic,
       LIVE_SNAPSHOT.distance
@@ -73,7 +73,7 @@ describe('BWC Integration', function () {
 
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
-      { position: LIVE_SNAPSHOT.position },
+      LIVE_SNAPSHOT.position,
       LIVE_SNAPSHOT.bearingTrue,
       LIVE_SNAPSHOT.bearingMagnetic,
       LIVE_SNAPSHOT.distance
@@ -107,9 +107,9 @@ describe('BWC Integration', function () {
 
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
-      { position: LIVE_SNAPSHOT.position },
+      LIVE_SNAPSHOT.position,
       LIVE_SNAPSHOT.bearingTrue,
-      undefined,
+      null,
       LIVE_SNAPSHOT.distance
     )
 
@@ -125,7 +125,7 @@ describe('BWC Integration', function () {
 
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
-      { position: LIVE_SNAPSHOT.position },
+      LIVE_SNAPSHOT.position,
       LIVE_SNAPSHOT.bearingTrue,
       LIVE_SNAPSHOT.bearingMagnetic,
       LIVE_SNAPSHOT.distance

--- a/test/BWC-integration.ts
+++ b/test/BWC-integration.ts
@@ -7,17 +7,30 @@ import * as assert from 'assert'
 import pluginFactory from '../src/index'
 import type { SignalKPlugin } from '../src/types/plugin'
 
-// Live snapshot from openplotter (vessel sailing near Marsh Harbour,
-// Bahamas, 9° W magnetic variation, route active with a Location-type
-// destination so the waypoint name has no published delta source).
+// Live snapshot captured from openplotter's deltastream (vessel sailing
+// near Marsh Harbour, Bahamas, 9° W magnetic variation, 3-point route
+// "TO DELETE" active, currently heading to point 1 of 3).
 const LIVE_SNAPSHOT = {
-  datetime: '2026-05-08T16:38:51.000Z',
-  position: { latitude: 26.547522602871112, longitude: -77.0623540878296 },
-  bearingTrue: 5.003988233815001,
-  bearingMagnetic: 4.843169020404653,
-  distance: 331.7225852823217,
+  datetime: '2026-05-08T19:32:22.000Z',
+  nextPoint: {
+    type: 'RoutePoint',
+    position: {
+      latitude: 26.547617287650734,
+      longitude: -77.05992185300417
+    }
+  },
+  activeRoute: {
+    href: '/resources/routes/d12f9af7-8556-440c-984a-a9795693fc8d',
+    name: 'TO DELETE',
+    reverse: false,
+    pointIndex: 0,
+    pointTotal: 3
+  },
+  bearingTrue: 5.890679316509219,
+  bearingMagnetic: 5.729787364152641,
+  distance: 127.040711001917,
   expectedSentence:
-    '$IIBWC,163851.00,2632.8514,N,07703.7412,W,286.7,T,277.5,M,0.18,N,*1B'
+    '$IIBWC,193222.00,2632.8570,N,07703.5953,W,337.5,T,328.3,M,0.07,N,TO DELETE/1*24'
 } as const
 
 describe('BWC Integration', function () {
@@ -57,7 +70,8 @@ describe('BWC Integration', function () {
 
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
-      LIVE_SNAPSHOT.position,
+      LIVE_SNAPSHOT.nextPoint,
+      LIVE_SNAPSHOT.activeRoute,
       LIVE_SNAPSHOT.bearingTrue,
       LIVE_SNAPSHOT.bearingMagnetic,
       LIVE_SNAPSHOT.distance
@@ -73,7 +87,8 @@ describe('BWC Integration', function () {
 
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
-      LIVE_SNAPSHOT.position,
+      LIVE_SNAPSHOT.nextPoint,
+      LIVE_SNAPSHOT.activeRoute,
       LIVE_SNAPSHOT.bearingTrue,
       LIVE_SNAPSHOT.bearingMagnetic,
       LIVE_SNAPSHOT.distance
@@ -97,7 +112,11 @@ describe('BWC Integration', function () {
     assert.equal(fields[9], 'M')
     assert.match(fields[10]!, /^\d+\.\d{2}$/, 'distance in NM')
     assert.equal(fields[11], 'N')
-    assert.equal(fields[12], '')
+    assert.equal(
+      fields[12],
+      'TO DELETE/1',
+      'waypoint ID derived from active route'
+    )
   })
 
   it('omits magnetic bearing fields when server does not publish it', () => {
@@ -107,7 +126,8 @@ describe('BWC Integration', function () {
 
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
-      LIVE_SNAPSHOT.position,
+      LIVE_SNAPSHOT.nextPoint,
+      LIVE_SNAPSHOT.activeRoute,
       LIVE_SNAPSHOT.bearingTrue,
       null,
       LIVE_SNAPSHOT.distance
@@ -125,7 +145,8 @@ describe('BWC Integration', function () {
 
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
-      LIVE_SNAPSHOT.position,
+      LIVE_SNAPSHOT.nextPoint,
+      LIVE_SNAPSHOT.activeRoute,
       LIVE_SNAPSHOT.bearingTrue,
       LIVE_SNAPSHOT.bearingMagnetic,
       LIVE_SNAPSHOT.distance

--- a/test/BWC.ts
+++ b/test/BWC.ts
@@ -5,9 +5,9 @@ import { createAppWithPlugin } from './testutil'
 type AnyApp = ReturnType<typeof createAppWithPlugin>
 
 /**
- * Real navigation snapshots captured from a live signalk-server (openplotter
- * sailing near Marsh Harbour, Bahamas, 9° west magnetic variation, route
- * active with a Location-type destination so nextPoint has no name).
+ * Real navigation snapshots captured from the live deltastream of a running
+ * signalk-server (openplotter sailing near Marsh Harbour, Bahamas, 9° west
+ * magnetic variation, route active with a Location-type destination).
  *
  * Kept verbatim so the test fixture documents the exact wire shape the
  * encoder must accept; do not "tidy" the long decimals.
@@ -18,7 +18,6 @@ const LIVE_SNAPSHOT_1 = {
   bearingTrue: 5.003988233815001, // 286.71° true
   bearingMagnetic: 4.843169020404653, // 277.49° magnetic
   distance: 331.7225852823217, // 0.179 NM
-  // Expected encoder output for this snapshot:
   expectedSentence:
     '$IIBWC,163851.00,2632.8514,N,07703.7412,W,286.7,T,277.5,M,0.18,N,*1B'
 } as const
@@ -33,14 +32,9 @@ const LIVE_SNAPSHOT_2 = {
     '$IIBWC,164000.00,2632.8514,N,07703.7412,W,287.0,T,277.8,M,0.18,N,*1B'
 } as const
 
-interface NextPointArg {
-  name?: string
-  position?: { latitude: number; longitude: number }
-}
-
 interface BwcOverrides {
   datetime?: string
-  nextPoint?: NextPointArg | null
+  position?: { latitude: number; longitude: number } | null
   bearingTrue?: number | undefined
   bearingMagnetic?: number | undefined | null
   distance?: number | undefined
@@ -51,11 +45,9 @@ function pushBwcStreams(app: AnyApp, overrides: BwcOverrides): void {
     .getSelfStream('navigation.datetime')
     .push(overrides.datetime ?? LIVE_SNAPSHOT_1.datetime)
   app.streambundle
-    .getSelfStream('navigation.courseGreatCircle.nextPoint')
+    .getSelfStream('navigation.courseGreatCircle.nextPoint.position')
     .push(
-      'nextPoint' in overrides
-        ? overrides.nextPoint
-        : { position: LIVE_SNAPSHOT_1.position }
+      'position' in overrides ? overrides.position : LIVE_SNAPSHOT_1.position
     )
   app.streambundle
     .getSelfStream('navigation.course.calcValues.bearingTrue')
@@ -138,7 +130,7 @@ describe('BWC', function () {
       const app = createAppWithPlugin(onEmit, 'BWC')
       pushBwcStreams(app, {
         datetime: LIVE_SNAPSHOT_2.datetime,
-        nextPoint: { position: LIVE_SNAPSHOT_2.position },
+        position: LIVE_SNAPSHOT_2.position,
         bearingTrue: LIVE_SNAPSHOT_2.bearingTrue,
         bearingMagnetic: LIVE_SNAPSHOT_2.bearingMagnetic,
         distance: LIVE_SNAPSHOT_2.distance
@@ -221,10 +213,19 @@ describe('BWC', function () {
       const app = createAppWithPlugin(onEmit, 'BWC')
       pushBwcStreams(app, {})
     })
+
+    it('emits an empty waypoint ID (no live delta source for the name today)', (done) => {
+      const onEmit = (_event: string, value: unknown): void => {
+        assert.equal(parseBwc(value as string).fields.waypointId, '')
+        done()
+      }
+      const app = createAppWithPlugin(onEmit, 'BWC')
+      pushBwcStreams(app, {})
+    })
   })
 
   describe('bearingMagnetic handling (optional field)', function () {
-    it('emits empty fields 8 and 9 when bearingMagnetic is undefined', (done) => {
+    it('emits empty fields 8 and 9 when bearingMagnetic is null (server seeded default)', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
         const { fields } = parseBwc(value as string)
         assert.equal(
@@ -243,6 +244,17 @@ describe('BWC', function () {
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
+      pushBwcStreams(app, { bearingMagnetic: null })
+    })
+
+    it('emits empty fields 8 and 9 when bearingMagnetic is undefined', (done) => {
+      const onEmit = (_event: string, value: unknown): void => {
+        const { fields } = parseBwc(value as string)
+        assert.equal(fields.bearingMagnetic, '')
+        assert.equal(fields.bearingMagneticIndicator, '')
+        done()
+      }
+      const app = createAppWithPlugin(onEmit, 'BWC')
       pushBwcStreams(app, { bearingMagnetic: undefined })
     })
 
@@ -253,64 +265,7 @@ describe('BWC', function () {
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
-      pushBwcStreams(app, { bearingMagnetic: undefined })
-    })
-  })
-
-  describe('waypoint name (field 12)', function () {
-    it('uses waypoint name verbatim when available', (done) => {
-      const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.waypointId, 'BAHAMAS_WP1')
-        done()
-      }
-      const app = createAppWithPlugin(onEmit, 'BWC')
-      pushBwcStreams(app, {
-        nextPoint: { position: LIVE_SNAPSHOT_1.position, name: 'BAHAMAS_WP1' }
-      })
-    })
-
-    it('uses empty field for Location-type destination (no name, real case)', (done) => {
-      // openplotter snapshot: nextPoint.value.value.type = "Location",
-      // value.href = null. The encoder receives nextPoint with no name field.
-      const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.waypointId, '')
-        done()
-      }
-      const app = createAppWithPlugin(onEmit, 'BWC')
-      pushBwcStreams(app, {})
-    })
-
-    it('truncates a name longer than 20 characters', (done) => {
-      const onEmit = (_event: string, value: unknown): void => {
-        const id = parseBwc(value as string).fields.waypointId!
-        assert.equal(id.length, 20)
-        assert.equal(id, 'AAAAAAAAAAAAAAAAAAAA')
-        done()
-      }
-      const app = createAppWithPlugin(onEmit, 'BWC')
-      pushBwcStreams(app, {
-        nextPoint: { position: LIVE_SNAPSHOT_1.position, name: 'A'.repeat(25) }
-      })
-    })
-
-    it('strips NMEA-reserved characters from the name', (done) => {
-      // A name like "BAD,WP*$NA\rM\nE" would otherwise inject fields,
-      // forge a checksum boundary, or terminate the sentence. All five
-      // reserved chars must be stripped before truncation/emission.
-      const onEmit = (_event: string, value: unknown): void => {
-        const { fields, body, fieldCount, checksum } = parseBwc(value as string)
-        assert.equal(fields.waypointId, 'BADWPNAME')
-        assert.equal(fieldCount, 13, 'no extra fields injected')
-        assert.equal(checksum, xorChecksum(body), 'checksum still valid')
-        done()
-      }
-      const app = createAppWithPlugin(onEmit, 'BWC')
-      pushBwcStreams(app, {
-        nextPoint: {
-          position: LIVE_SNAPSHOT_1.position,
-          name: 'BAD,WP*$NA\rM\nE'
-        }
-      })
+      pushBwcStreams(app, { bearingMagnetic: null })
     })
   })
 
@@ -346,10 +301,8 @@ describe('BWC', function () {
     }
 
     // -- bearing equivalence classes --
-    expectEmits(
-      'bearing 0 rad emits "0.0" (equator/poles boundary)',
-      { bearingTrue: 0 },
-      (s) => assert.equal(parseBwc(s).fields.bearingTrue, '0.0')
+    expectEmits('bearing 0 rad emits "0.0"', { bearingTrue: 0 }, (s) =>
+      assert.equal(parseBwc(s).fields.bearingTrue, '0.0')
     )
     expectEmits(
       'bearing 2π emits in [0, 360), wrapping to 0.0',
@@ -380,48 +333,48 @@ describe('BWC', function () {
     // -- latitude equivalence classes --
     expectEmits(
       'latitude exactly +90 (north pole, boundary inclusive)',
-      { nextPoint: { position: { latitude: 90, longitude: 0 } } },
+      { position: { latitude: 90, longitude: 0 } },
       (s) => assert.equal(parseBwc(s).fields.latitude, '9000.0000,N')
     )
     expectEmits(
       'latitude exactly -90 (south pole, boundary inclusive)',
-      { nextPoint: { position: { latitude: -90, longitude: 0 } } },
+      { position: { latitude: -90, longitude: 0 } },
       (s) => assert.equal(parseBwc(s).fields.latitude, '9000.0000,S')
     )
     expectEmits(
       'latitude 0 (equator)',
-      { nextPoint: { position: { latitude: 0, longitude: 0 } } },
+      { position: { latitude: 0, longitude: 0 } },
       (s) => assert.equal(parseBwc(s).fields.latitude, '0000.0000,N')
     )
 
     // -- longitude equivalence classes --
     expectEmits(
       'longitude exactly +180 (antimeridian, accepted by codebase convention)',
-      { nextPoint: { position: { latitude: 0, longitude: 180 } } },
+      { position: { latitude: 0, longitude: 180 } },
       (s) => assert.equal(parseBwc(s).fields.longitude, '18000.0000,E')
     )
     expectEmits(
       'longitude -179.9999 (just inside western antimeridian)',
-      { nextPoint: { position: { latitude: 0, longitude: -179.9999 } } },
+      { position: { latitude: 0, longitude: -179.9999 } },
       (s) => assert.match(parseBwc(s).fields.longitude!, /^17959\.\d{4},W$/)
     )
     expectNoEmit(
       'rejects longitude exactly -180 (codebase treats antimeridian as +180 only)',
-      { nextPoint: { position: { latitude: 0, longitude: -180 } } }
+      { position: { latitude: 0, longitude: -180 } }
     )
 
     // -- rejection paths --
     expectNoEmit('rejects latitude > 90', {
-      nextPoint: { position: { latitude: 91, longitude: 0 } }
+      position: { latitude: 91, longitude: 0 }
     })
     expectNoEmit('rejects latitude < -90', {
-      nextPoint: { position: { latitude: -91, longitude: 0 } }
+      position: { latitude: -91, longitude: 0 }
     })
     expectNoEmit('rejects longitude > 180', {
-      nextPoint: { position: { latitude: 0, longitude: 181 } }
+      position: { latitude: 0, longitude: 181 }
     })
     expectNoEmit('rejects longitude < -180', {
-      nextPoint: { position: { latitude: 0, longitude: -181 } }
+      position: { latitude: 0, longitude: -181 }
     })
     expectNoEmit('rejects NaN bearingTrue', { bearingTrue: NaN })
     expectNoEmit('rejects Infinity bearingTrue', { bearingTrue: Infinity })
@@ -430,10 +383,7 @@ describe('BWC', function () {
     expectNoEmit('rejects negative distance', { distance: -10 })
     expectNoEmit('rejects undefined bearingTrue', { bearingTrue: undefined })
     expectNoEmit('rejects undefined distance', { distance: undefined })
-    expectNoEmit('rejects null nextPoint', { nextPoint: null })
-    expectNoEmit('rejects nextPoint with no position', {
-      nextPoint: { name: 'NOPOS' }
-    })
+    expectNoEmit('rejects null position', { position: null })
     expectNoEmit('rejects empty datetime', { datetime: '' })
     expectNoEmit('rejects unparseable datetime', { datetime: 'not-a-date' })
   })
@@ -472,10 +422,29 @@ describe('BWC', function () {
       const bwc = require('../src/sentences/BWC').default(stubApp)
       assert.deepStrictEqual(bwc.keys, [
         'navigation.datetime',
-        'navigation.courseGreatCircle.nextPoint',
+        'navigation.courseGreatCircle.nextPoint.position',
         'navigation.course.calcValues.bearingTrue',
         'navigation.course.calcValues.bearingMagnetic',
         'navigation.course.calcValues.distance'
+      ])
+    })
+
+    it('seeds bearingMagnetic with null so the combined stream fires without it', () => {
+      const stubApp = {
+        streambundle: {
+          getSelfStream: (): unknown => ({ toProperty: () => ({}) })
+        },
+        emit: (): void => {},
+        debug: (): void => {}
+      }
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const bwc = require('../src/sentences/BWC').default(stubApp)
+      assert.deepStrictEqual(bwc.defaults, [
+        '',
+        undefined,
+        undefined,
+        null,
+        undefined
       ])
     })
   })

--- a/test/BWC.ts
+++ b/test/BWC.ts
@@ -7,34 +7,53 @@ type AnyApp = ReturnType<typeof createAppWithPlugin>
 /**
  * Real navigation snapshots captured from the live deltastream of a running
  * signalk-server (openplotter sailing near Marsh Harbour, Bahamas, 9° west
- * magnetic variation, route active with a Location-type destination).
+ * magnetic variation, 3-point route active "TO DELETE").
  *
  * Kept verbatim so the test fixture documents the exact wire shape the
  * encoder must accept; do not "tidy" the long decimals.
  */
 const LIVE_SNAPSHOT_1 = {
-  datetime: '2026-05-08T16:38:51.000Z',
-  position: { latitude: 26.547522602871112, longitude: -77.0623540878296 },
-  bearingTrue: 5.003988233815001, // 286.71° true
-  bearingMagnetic: 4.843169020404653, // 277.49° magnetic
-  distance: 331.7225852823217, // 0.179 NM
+  datetime: '2026-05-08T19:32:22.000Z',
+  // navigation.course.nextPoint is published as a composite delta:
+  nextPoint: {
+    type: 'RoutePoint',
+    position: {
+      latitude: 26.547617287650734,
+      longitude: -77.05992185300417
+    }
+  },
+  // navigation.course.activeRoute is published as a composite delta:
+  activeRoute: {
+    href: '/resources/routes/d12f9af7-8556-440c-984a-a9795693fc8d',
+    name: 'TO DELETE',
+    reverse: false,
+    pointIndex: 0,
+    pointTotal: 3
+  },
+  bearingTrue: 5.890679316509219, // 337.5° true
+  bearingMagnetic: 5.729787364152641, // 328.3° magnetic
+  distance: 127.040711001917, // 0.07 NM
   expectedSentence:
-    '$IIBWC,163851.00,2632.8514,N,07703.7412,W,286.7,T,277.5,M,0.18,N,*1B'
+    '$IIBWC,193222.00,2632.8570,N,07703.5953,W,337.5,T,328.3,M,0.07,N,TO DELETE/1*24'
 } as const
 
-const LIVE_SNAPSHOT_2 = {
-  datetime: '2026-05-08T16:40:00.000Z',
-  position: { latitude: 26.547522602871112, longitude: -77.0623540878296 },
-  bearingTrue: 5.0093362657001945, // 287.01° true
-  bearingMagnetic: 4.848517052289846, // 277.80° magnetic
-  distance: 330.35359211264006, // 0.178 NM
-  expectedSentence:
-    '$IIBWC,164000.00,2632.8514,N,07703.7412,W,287.0,T,277.8,M,0.18,N,*1B'
-} as const
+interface NextPointArg {
+  type?: string
+  position?: { latitude: number; longitude: number }
+  name?: string
+}
+
+interface ActiveRouteArg {
+  href?: string | null
+  name?: string | null
+  pointIndex?: number | null
+  pointTotal?: number | null
+}
 
 interface BwcOverrides {
   datetime?: string
-  position?: { latitude: number; longitude: number } | null
+  nextPoint?: NextPointArg | null
+  activeRoute?: ActiveRouteArg
   bearingTrue?: number | undefined
   bearingMagnetic?: number | undefined | null
   distance?: number | undefined
@@ -45,10 +64,19 @@ function pushBwcStreams(app: AnyApp, overrides: BwcOverrides): void {
     .getSelfStream('navigation.datetime')
     .push(overrides.datetime ?? LIVE_SNAPSHOT_1.datetime)
   app.streambundle
-    .getSelfStream('navigation.courseGreatCircle.nextPoint.position')
+    .getSelfStream('navigation.course.nextPoint')
     .push(
-      'position' in overrides ? overrides.position : LIVE_SNAPSHOT_1.position
+      'nextPoint' in overrides ? overrides.nextPoint : LIVE_SNAPSHOT_1.nextPoint
     )
+  if ('activeRoute' in overrides) {
+    app.streambundle
+      .getSelfStream('navigation.course.activeRoute')
+      .push(overrides.activeRoute)
+  } else {
+    app.streambundle
+      .getSelfStream('navigation.course.activeRoute')
+      .push(LIVE_SNAPSHOT_1.activeRoute)
+  }
   app.streambundle
     .getSelfStream('navigation.course.calcValues.bearingTrue')
     .push(
@@ -112,29 +140,14 @@ function xorChecksum(body: string): string {
 }
 
 describe('BWC', function () {
-  describe('real-world snapshots from openplotter', function () {
-    it('reproduces the exact sentence from live snapshot 1', (done) => {
+  describe('real-world snapshot from openplotter', function () {
+    it('reproduces the exact sentence captured from a live 3-point route', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
         assert.equal(value, LIVE_SNAPSHOT_1.expectedSentence)
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
       pushBwcStreams(app, {})
-    })
-
-    it('reproduces the exact sentence from live snapshot 2 (vessel moved)', (done) => {
-      const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(value, LIVE_SNAPSHOT_2.expectedSentence)
-        done()
-      }
-      const app = createAppWithPlugin(onEmit, 'BWC')
-      pushBwcStreams(app, {
-        datetime: LIVE_SNAPSHOT_2.datetime,
-        position: LIVE_SNAPSHOT_2.position,
-        bearingTrue: LIVE_SNAPSHOT_2.bearingTrue,
-        bearingMagnetic: LIVE_SNAPSHOT_2.bearingMagnetic,
-        distance: LIVE_SNAPSHOT_2.distance
-      })
     })
 
     it('emits a structurally complete sentence: 13 fields and valid checksum', (done) => {
@@ -152,7 +165,7 @@ describe('BWC', function () {
   describe('field formatting from live data', function () {
     it('formats UTC time as HHMMSS.ss', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.time, '163851.00')
+        assert.equal(parseBwc(value as string).fields.time, '193222.00')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
@@ -161,8 +174,7 @@ describe('BWC', function () {
 
     it('formats latitude as DDMM.MMMM with N/S indicator', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        // 26.547522602871112° → 26°32.8514' N
-        assert.equal(parseBwc(value as string).fields.latitude, '2632.8514,N')
+        assert.equal(parseBwc(value as string).fields.latitude, '2632.8570,N')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
@@ -171,8 +183,7 @@ describe('BWC', function () {
 
     it('formats longitude as DDDMM.MMMM with E/W indicator', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        // -77.0623540878296° → 077°03.7412' W
-        assert.equal(parseBwc(value as string).fields.longitude, '07703.7412,W')
+        assert.equal(parseBwc(value as string).fields.longitude, '07703.5953,W')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
@@ -182,8 +193,7 @@ describe('BWC', function () {
     it('formats bearing as degrees with one decimal', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
         const { fields } = parseBwc(value as string)
-        // 5.003988233815001 rad = 286.7074° → "286.7"
-        assert.equal(fields.bearingTrue, '286.7')
+        assert.equal(fields.bearingTrue, '337.5')
         assert.equal(fields.bearingTrueIndicator, 'T')
         done()
       }
@@ -192,11 +202,8 @@ describe('BWC', function () {
     })
 
     it('uses server-provided bearingMagnetic verbatim, not derived from variation', (done) => {
-      // openplotter publishes bearingMagnetic at 277.49°. variation is
-      // -9.21° (W). Naive `mag = true - var` would produce 295.92°,
-      // which is wrong. The encoder must consume bearingMagnetic directly.
       const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.bearingMagnetic, '277.5')
+        assert.equal(parseBwc(value as string).fields.bearingMagnetic, '328.3')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
@@ -205,18 +212,9 @@ describe('BWC', function () {
 
     it('converts distance from meters to nautical miles with two decimals', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        // 331.7225852823217 m × 0.000539957 = 0.1791 NM → "0.18"
-        assert.equal(parseBwc(value as string).fields.distance, '0.18')
+        // 127.04 m × 0.000539957 = 0.0686 NM → "0.07"
+        assert.equal(parseBwc(value as string).fields.distance, '0.07')
         assert.equal(parseBwc(value as string).fields.distanceUnit, 'N')
-        done()
-      }
-      const app = createAppWithPlugin(onEmit, 'BWC')
-      pushBwcStreams(app, {})
-    })
-
-    it('emits an empty waypoint ID (no live delta source for the name today)', (done) => {
-      const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.waypointId, '')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
@@ -224,22 +222,117 @@ describe('BWC', function () {
     })
   })
 
+  describe('waypoint ID derivation (field 12)', function () {
+    it('uses route name + /pointIndex+1 for multi-point routes', (done) => {
+      const onEmit = (_event: string, value: unknown): void => {
+        // pointIndex=0 of pointTotal=3 → "TO DELETE/1"
+        assert.equal(parseBwc(value as string).fields.waypointId, 'TO DELETE/1')
+        done()
+      }
+      const app = createAppWithPlugin(onEmit, 'BWC')
+      pushBwcStreams(app, {})
+    })
+
+    it('uses route name alone for single-point routes', (done) => {
+      const onEmit = (_event: string, value: unknown): void => {
+        assert.equal(parseBwc(value as string).fields.waypointId, 'SOLO')
+        done()
+      }
+      const app = createAppWithPlugin(onEmit, 'BWC')
+      pushBwcStreams(app, {
+        activeRoute: { name: 'SOLO', pointIndex: 0, pointTotal: 1 }
+      })
+    })
+
+    it('prefers nextPoint.name when present (forward-compat with SignalK#2595)', (done) => {
+      const onEmit = (_event: string, value: unknown): void => {
+        assert.equal(parseBwc(value as string).fields.waypointId, 'WP-A')
+        done()
+      }
+      const app = createAppWithPlugin(onEmit, 'BWC')
+      pushBwcStreams(app, {
+        nextPoint: {
+          type: 'RoutePoint',
+          position: LIVE_SNAPSHOT_1.nextPoint.position,
+          name: 'WP-A'
+        }
+      })
+    })
+
+    it('emits empty waypoint ID for a Location-type destination with no route', (done) => {
+      const onEmit = (_event: string, value: unknown): void => {
+        assert.equal(parseBwc(value as string).fields.waypointId, '')
+        done()
+      }
+      const app = createAppWithPlugin(onEmit, 'BWC')
+      pushBwcStreams(app, {
+        nextPoint: {
+          type: 'Location',
+          position: LIVE_SNAPSHOT_1.nextPoint.position
+        },
+        activeRoute: { href: null, name: null }
+      })
+    })
+
+    it('emits empty waypoint ID when activeRoute stream is the {} default', (done) => {
+      const onEmit = (_event: string, value: unknown): void => {
+        assert.equal(parseBwc(value as string).fields.waypointId, '')
+        done()
+      }
+      const app = createAppWithPlugin(onEmit, 'BWC')
+      pushBwcStreams(app, {
+        nextPoint: {
+          type: 'Location',
+          position: LIVE_SNAPSHOT_1.nextPoint.position
+        },
+        activeRoute: {}
+      })
+    })
+
+    it('truncates a name longer than 20 characters', (done) => {
+      const onEmit = (_event: string, value: unknown): void => {
+        const id = parseBwc(value as string).fields.waypointId!
+        assert.equal(id.length, 20)
+        assert.equal(id, 'A'.repeat(20))
+        done()
+      }
+      const app = createAppWithPlugin(onEmit, 'BWC')
+      pushBwcStreams(app, {
+        nextPoint: {
+          type: 'RoutePoint',
+          position: LIVE_SNAPSHOT_1.nextPoint.position,
+          name: 'A'.repeat(25)
+        }
+      })
+    })
+
+    it('strips NMEA-reserved characters from the name', (done) => {
+      const onEmit = (_event: string, value: unknown): void => {
+        const { fields, body, fieldCount, checksum } = parseBwc(value as string)
+        assert.equal(fields.waypointId, 'BADWPNAME')
+        assert.equal(fieldCount, 13, 'no extra fields injected')
+        assert.equal(checksum, xorChecksum(body), 'checksum still valid')
+        done()
+      }
+      const app = createAppWithPlugin(onEmit, 'BWC')
+      pushBwcStreams(app, {
+        nextPoint: {
+          type: 'RoutePoint',
+          position: LIVE_SNAPSHOT_1.nextPoint.position,
+          name: 'BAD,WP*$NA\rM\nE'
+        }
+      })
+    })
+  })
+
   describe('bearingMagnetic handling (optional field)', function () {
     it('emits empty fields 8 and 9 when bearingMagnetic is null (server seeded default)', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
         const { fields } = parseBwc(value as string)
-        assert.equal(
-          fields.bearingMagnetic,
-          '',
-          'field 8 must be empty when magnetic is unknown'
-        )
-        assert.equal(
-          fields.bearingMagneticIndicator,
-          '',
-          'field 9 must be empty when field 8 is empty'
-        )
+        assert.equal(fields.bearingMagnetic, '')
+        assert.equal(fields.bearingMagneticIndicator, '')
         // True bearing must still be present
-        assert.equal(fields.bearingTrue, '286.7')
+        assert.equal(fields.bearingTrue, '337.5')
         assert.equal(fields.bearingTrueIndicator, 'T')
         done()
       }
@@ -333,48 +426,74 @@ describe('BWC', function () {
     // -- latitude equivalence classes --
     expectEmits(
       'latitude exactly +90 (north pole, boundary inclusive)',
-      { position: { latitude: 90, longitude: 0 } },
+      {
+        nextPoint: {
+          type: 'Location',
+          position: { latitude: 90, longitude: 0 }
+        }
+      },
       (s) => assert.equal(parseBwc(s).fields.latitude, '9000.0000,N')
     )
     expectEmits(
       'latitude exactly -90 (south pole, boundary inclusive)',
-      { position: { latitude: -90, longitude: 0 } },
+      {
+        nextPoint: {
+          type: 'Location',
+          position: { latitude: -90, longitude: 0 }
+        }
+      },
       (s) => assert.equal(parseBwc(s).fields.latitude, '9000.0000,S')
-    )
-    expectEmits(
-      'latitude 0 (equator)',
-      { position: { latitude: 0, longitude: 0 } },
-      (s) => assert.equal(parseBwc(s).fields.latitude, '0000.0000,N')
     )
 
     // -- longitude equivalence classes --
     expectEmits(
       'longitude exactly +180 (antimeridian, accepted by codebase convention)',
-      { position: { latitude: 0, longitude: 180 } },
+      {
+        nextPoint: {
+          type: 'Location',
+          position: { latitude: 0, longitude: 180 }
+        }
+      },
       (s) => assert.equal(parseBwc(s).fields.longitude, '18000.0000,E')
     )
     expectEmits(
       'longitude -179.9999 (just inside western antimeridian)',
-      { position: { latitude: 0, longitude: -179.9999 } },
+      {
+        nextPoint: {
+          type: 'Location',
+          position: { latitude: 0, longitude: -179.9999 }
+        }
+      },
       (s) => assert.match(parseBwc(s).fields.longitude!, /^17959\.\d{4},W$/)
     )
     expectNoEmit(
       'rejects longitude exactly -180 (codebase treats antimeridian as +180 only)',
-      { position: { latitude: 0, longitude: -180 } }
+      {
+        nextPoint: {
+          type: 'Location',
+          position: { latitude: 0, longitude: -180 }
+        }
+      }
     )
 
     // -- rejection paths --
     expectNoEmit('rejects latitude > 90', {
-      position: { latitude: 91, longitude: 0 }
+      nextPoint: {
+        type: 'Location',
+        position: { latitude: 91, longitude: 0 }
+      }
     })
     expectNoEmit('rejects latitude < -90', {
-      position: { latitude: -91, longitude: 0 }
+      nextPoint: {
+        type: 'Location',
+        position: { latitude: -91, longitude: 0 }
+      }
     })
     expectNoEmit('rejects longitude > 180', {
-      position: { latitude: 0, longitude: 181 }
-    })
-    expectNoEmit('rejects longitude < -180', {
-      position: { latitude: 0, longitude: -181 }
+      nextPoint: {
+        type: 'Location',
+        position: { latitude: 0, longitude: 181 }
+      }
     })
     expectNoEmit('rejects NaN bearingTrue', { bearingTrue: NaN })
     expectNoEmit('rejects Infinity bearingTrue', { bearingTrue: Infinity })
@@ -383,34 +502,37 @@ describe('BWC', function () {
     expectNoEmit('rejects negative distance', { distance: -10 })
     expectNoEmit('rejects undefined bearingTrue', { bearingTrue: undefined })
     expectNoEmit('rejects undefined distance', { distance: undefined })
-    expectNoEmit('rejects null position', { position: null })
+    expectNoEmit('rejects null nextPoint', { nextPoint: null })
+    expectNoEmit('rejects nextPoint with no position', {
+      nextPoint: { type: 'Location' }
+    })
     expectNoEmit('rejects empty datetime', { datetime: '' })
     expectNoEmit('rejects unparseable datetime', { datetime: 'not-a-date' })
   })
 
   describe('datetime handling', function () {
     it('converts ISO datetime with timezone offset to UTC', (done) => {
-      // 18:38:51 +02:00 -> 16:38:51 UTC, matches LIVE_SNAPSHOT_1
       const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.time, '163851.00')
+        // 21:32:22 +02:00 -> 19:32:22 UTC, matches LIVE_SNAPSHOT_1
+        assert.equal(parseBwc(value as string).fields.time, '193222.00')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
-      pushBwcStreams(app, { datetime: '2026-05-08T18:38:51+02:00' })
+      pushBwcStreams(app, { datetime: '2026-05-08T21:32:22+02:00' })
     })
 
     it('preserves fractional seconds as centiseconds', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.time, '163851.78')
+        assert.equal(parseBwc(value as string).fields.time, '193222.78')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
-      pushBwcStreams(app, { datetime: '2026-05-08T16:38:51.789Z' })
+      pushBwcStreams(app, { datetime: '2026-05-08T19:32:22.789Z' })
     })
   })
 
   describe('Signal K subscription metadata', function () {
-    it('subscribes to the five required Signal K paths in order', () => {
+    it('subscribes to the six required Signal K paths in order', () => {
       const stubApp = {
         streambundle: {
           getSelfStream: (): unknown => ({ toProperty: () => ({}) })
@@ -422,14 +544,15 @@ describe('BWC', function () {
       const bwc = require('../src/sentences/BWC').default(stubApp)
       assert.deepStrictEqual(bwc.keys, [
         'navigation.datetime',
-        'navigation.courseGreatCircle.nextPoint.position',
+        'navigation.course.nextPoint',
+        'navigation.course.activeRoute',
         'navigation.course.calcValues.bearingTrue',
         'navigation.course.calcValues.bearingMagnetic',
         'navigation.course.calcValues.distance'
       ])
     })
 
-    it('seeds bearingMagnetic with null so the combined stream fires without it', () => {
+    it('seeds activeRoute with {} and bearingMagnetic with null so the combined stream fires', () => {
       const stubApp = {
         streambundle: {
           getSelfStream: (): unknown => ({ toProperty: () => ({}) })
@@ -442,6 +565,7 @@ describe('BWC', function () {
       assert.deepStrictEqual(bwc.defaults, [
         '',
         undefined,
+        {},
         undefined,
         null,
         undefined

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -43,7 +43,8 @@ const expectations: Expectation[] = [
     title: 'BWC - Bearing and distance to waypoint',
     keys: [
       'navigation.datetime',
-      'navigation.courseGreatCircle.nextPoint.position',
+      'navigation.course.nextPoint',
+      'navigation.course.activeRoute',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.calcValues.bearingMagnetic',
       'navigation.course.calcValues.distance'

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -43,7 +43,7 @@ const expectations: Expectation[] = [
     title: 'BWC - Bearing and distance to waypoint',
     keys: [
       'navigation.datetime',
-      'navigation.courseGreatCircle.nextPoint',
+      'navigation.courseGreatCircle.nextPoint.position',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.calcValues.bearingMagnetic',
       'navigation.course.calcValues.distance'


### PR DESCRIPTION
## Summary

The BWC encoder shipped in v1.17.0-beta.0 never emits in production. The path subscription was wrong: \`navigation.courseGreatCircle.nextPoint\` is only a tree node — its parent never emits a delta, only its leaf children do — so the combined Bacon stream waited forever even with an active route and all other source paths flowing.

The canonical waypoint path is **\`navigation.course.nextPoint\`**, which is published as a single composite delta containing \`type\` and \`position\` regardless of whether the active calc method is GreatCircle or Rhumbline.

## Verified live deltastream behavior

8-second WebSocket subscription against a running openplotter:

\`\`\`
FLOWS: navigation.course.nextPoint
       value: {"type":"RoutePoint","position":{"latitude":...,"longitude":...}}
FLOWS: navigation.course.activeRoute
       value: {"href":"/resources/routes/...","name":"TO DELETE","pointIndex":0,"pointTotal":3}
FLOWS: navigation.course.calcValues.bearingTrue / bearingMagnetic / distance
FLOWS: navigation.datetime
SILENT (no delta in 8s):
  navigation.courseGreatCircle.nextPoint
  navigation.courseGreatCircle.nextPoint.position  (in earlier probe also flowed but is the wrong abstraction)
\`\`\`

## Changes

- Subscribe to \`navigation.course.nextPoint\` (canonical, composite \`{type, position, [name]}\`).
- Subscribe to \`navigation.course.activeRoute\` (composite \`{href, name, pointIndex, pointTotal}\`) for the waypoint ID.
- Waypoint ID derivation:
  1. \`nextPoint.name\` when present (forward-compat with SignalK/signalk-server#2595)
  2. \`activeRoute.name\` + \`/\${pointIndex+1}\` for multi-point routes
  3. \`activeRoute.name\` alone for single-point routes
  4. empty for Location-type destinations with no route
- \`activeRoute\` defaults to \`{}\` so Location-type destinations still emit; \`bearingMagnetic\` seeds with \`null\` so older servers that don't publish it still let the encoder fire (fields 8/9 emitted empty per NMEA "value unknown" convention).

## Live verification

Connected the new encoder code directly to openplotter's deltastream:

\`\`\`
=== Live values ===
datetime:     2026-05-08T19:43:25.000Z
nextPoint:    {"type":"RoutePoint","position":{"latitude":26.547617287650734,"longitude":-77.05992185300417}}
activeRoute:  {"href":".../d12f9af7-...","name":"TO DELETE","reverse":false,"pointIndex":0,"pointTotal":3}
bearingTrue:  5.908522694593084
bearingMag:   5.747630742236505
distance:     120.55324169182043
--- Emitted ---
\$IIBWC,194325.00,2632.8570,N,07703.5953,W,338.5,T,329.3,M,0.07,N,TO DELETE/1*2B
\`\`\`

## Test plan

- [x] All 339 unit/integration tests pass; the real-world snapshot is taken from the same openplotter session
- [x] \`tsc --noEmit\` clean
- [x] \`prettier:check\` clean
- [x] Live deltastream verification produces a correct sentence with the expected fields and a valid checksum