### PR TITLE
fix(BWC): emit "WP <N>" for field 12 instead of route name

### DIFF
--- a/src/sentences/BWC.ts
+++ b/src/sentences/BWC.ts
@@ -37,10 +37,9 @@ The parallel `navigation.courseGreatCircle.nextPoint` is silent on the
 deltastream (only its leaf children emit) and is NOT what to subscribe to.
 
 Waypoint name resolution (field 12):
-  1. nextPoint.name when SignalK/signalk-server#2595 lands
-  2. activeRoute.name with /pointIndex when a multi-point route is active
-  3. activeRoute.name alone for a single-point route
-  4. empty when the destination is a Location-type point with no route
+  1. nextPoint.name when SignalK/signalk-server#2608 lands
+  2. "WP <pointIndex+1>" when a route is active (e.g. "WP 1", "WP 2")
+  3. empty when the destination is a Location-type point with no route
 
 Bearing values reflect the calcMethod set in signalk-server (GreatCircle or
 Rhumbline). For typical sailing distances the difference is negligible; if
@@ -88,17 +87,12 @@ function deriveWaypointId(
   if (typeof nextPoint.name === 'string' && nextPoint.name.length > 0) {
     return nextPoint.name
   }
-  // Fall back to the active route's name. Append the 1-based point index
-  // when the route has more than one point so successive BWCs are distinct.
-  if (typeof activeRoute.name === 'string' && activeRoute.name.length > 0) {
-    if (
-      typeof activeRoute.pointIndex === 'number' &&
-      typeof activeRoute.pointTotal === 'number' &&
-      activeRoute.pointTotal > 1
-    ) {
-      return `${activeRoute.name}/${activeRoute.pointIndex + 1}`
-    }
-    return activeRoute.name
+  // Synthesize "WP N" from the active route's 1-based point index. Works
+  // for both single- and multi-point routes; chartplotters use this field
+  // primarily to distinguish successive waypoints, which "WP 1" / "WP 2"
+  // does without leaking a potentially noisy route name into the sentence.
+  if (typeof activeRoute.pointIndex === 'number') {
+    return `WP ${activeRoute.pointIndex + 1}`
   }
   return ''
 }

--- a/test/BWC-integration.ts
+++ b/test/BWC-integration.ts
@@ -30,7 +30,7 @@ const LIVE_SNAPSHOT = {
   bearingMagnetic: 5.729787364152641,
   distance: 127.040711001917,
   expectedSentence:
-    '$IIBWC,193222.00,2632.8570,N,07703.5953,W,337.5,T,328.3,M,0.07,N,TO DELETE/1*24'
+    '$IIBWC,193222.00,2632.8570,N,07703.5953,W,337.5,T,328.3,M,0.07,N,WP 1*0E'
 } as const
 
 describe('BWC Integration', function () {
@@ -114,8 +114,8 @@ describe('BWC Integration', function () {
     assert.equal(fields[11], 'N')
     assert.equal(
       fields[12],
-      'TO DELETE/1',
-      'waypoint ID derived from active route'
+      'WP 1',
+      'waypoint ID synthesized as "WP <pointIndex+1>"'
     )
   })
 

--- a/test/BWC.ts
+++ b/test/BWC.ts
@@ -34,7 +34,7 @@ const LIVE_SNAPSHOT_1 = {
   bearingMagnetic: 5.729787364152641, // 328.3° magnetic
   distance: 127.040711001917, // 0.07 NM
   expectedSentence:
-    '$IIBWC,193222.00,2632.8570,N,07703.5953,W,337.5,T,328.3,M,0.07,N,TO DELETE/1*24'
+    '$IIBWC,193222.00,2632.8570,N,07703.5953,W,337.5,T,328.3,M,0.07,N,WP 1*0E'
 } as const
 
 interface NextPointArg {
@@ -223,19 +223,30 @@ describe('BWC', function () {
   })
 
   describe('waypoint ID derivation (field 12)', function () {
-    it('uses route name + /pointIndex+1 for multi-point routes', (done) => {
+    it('emits "WP <pointIndex+1>" for the first point of a multi-point route', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        // pointIndex=0 of pointTotal=3 → "TO DELETE/1"
-        assert.equal(parseBwc(value as string).fields.waypointId, 'TO DELETE/1')
+        // pointIndex=0 → "WP 1"
+        assert.equal(parseBwc(value as string).fields.waypointId, 'WP 1')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
       pushBwcStreams(app, {})
     })
 
-    it('uses route name alone for single-point routes', (done) => {
+    it('emits "WP 3" when pointIndex advances to the third leg', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.waypointId, 'SOLO')
+        assert.equal(parseBwc(value as string).fields.waypointId, 'WP 3')
+        done()
+      }
+      const app = createAppWithPlugin(onEmit, 'BWC')
+      pushBwcStreams(app, {
+        activeRoute: { ...LIVE_SNAPSHOT_1.activeRoute, pointIndex: 2 }
+      })
+    })
+
+    it('emits "WP 1" for a single-point route (does not use the route name)', (done) => {
+      const onEmit = (_event: string, value: unknown): void => {
+        assert.equal(parseBwc(value as string).fields.waypointId, 'WP 1')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
@@ -244,7 +255,7 @@ describe('BWC', function () {
       })
     })
 
-    it('prefers nextPoint.name when present (forward-compat with SignalK#2595)', (done) => {
+    it('prefers nextPoint.name when the server populates it (SignalK#2608)', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
         assert.equal(parseBwc(value as string).fields.waypointId, 'WP-A')
         done()


### PR DESCRIPTION
## Summary

Drop the route-name fallback for BWC's field 12 (Waypoint ID). Synthesize a neutral, stable identifier from the active route's 1-based pointIndex instead.

| Server state | beta.1 emitted | beta.2 emits |
|---|---|---|
| nextPoint.name populated (after SignalK/signalk-server#2608) | per-waypoint name | per-waypoint name (unchanged) |
| 3-point route, pointIndex 0 | \`TO DELETE/1\` | \`WP 1\` |
| 3-point route, pointIndex 2 | \`TO DELETE/3\` | \`WP 3\` |
| Single-point route | \`SOLO\` | \`WP 1\` |
| Location destination, no route | empty | empty (unchanged) |

## Why

Route names are user-typed and frequently noisy ("TO DELETE", "test 12345", profanity, etc.) — leaking them into a published NMEA sentence is a behaviour we'd rather not ship as a default. \`WP 1\` / \`WP 2\` is enough for receivers to distinguish successive waypoints on the same active route. When the server does have a clean per-waypoint name (#2608), that wins via the existing priority-1 path.

## Live verification

\`\`\`
=== Live values ===
datetime:     2026-05-08T20:31:52.000Z
nextPoint:    {"type":"RoutePoint","position":{...}}
activeRoute:  {"href":".../d12f9af7-...","name":"LUKI","reverse":false,"pointIndex":0,"pointTotal":3}
bearingTrue:  0.9016086817022038
bearingMag:   0.7407172055904004
distance:     207.4023116806178
--- Emitted ---
\$IIBWC,203152.00,2632.8658,N,07703.4709,W,51.7,T,42.4,M,0.11,N,WP 1*07
\`\`\`

(The route name "LUKI" is correctly ignored.)

## Test plan

- [x] All 340 unit/integration tests pass
- [x] \`tsc --noEmit\` clean
- [x] \`prettier:check\` clean
- [x] Live deltastream verification produces the expected \`WP 1\` field