### PR TITLE
fix(routing): synthesize waypoint name (DP/VP/WP1), forward-compat with signalk-server#2608

### DIFF
--- a/scripts/capture-snapshot.ts
+++ b/scripts/capture-snapshot.ts
@@ -1,0 +1,98 @@
+/*
+ * Capture a Signal K deltastream snapshot.
+ *
+ * Connects to a running signalk-server, subscribes to the full delta
+ * stream for `vessels.self`, accumulates the latest value seen on every
+ * navigation/environment/steering path, and writes the result to a JSON
+ * file consumable by `scripts/probe-snapshot.ts` and the integration
+ * tests under `test/snapshots/`.
+ *
+ * Usage:
+ *   npx tsx scripts/capture-snapshot.ts <ws-url> <out.json> [scenario-name]
+ *
+ * Example:
+ *   npx tsx scripts/capture-snapshot.ts \
+ *     wss://10.10.10.143/signalk/v1/stream \
+ *     test/snapshots/route.json \
+ *     "navigate-with-active-route"
+ */
+import * as fs from 'fs'
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const WebSocket = require('ws')
+
+const url = process.argv[2]
+const outFile = process.argv[3]
+const scenarioName = process.argv[4] ?? 'unnamed-scenario'
+const captureSeconds = 9
+
+if (!url || !outFile) {
+  console.error(
+    'Usage: capture-snapshot.ts <ws-url> <out.json> [scenario-name]'
+  )
+  process.exit(2)
+}
+
+function shouldInclude(p: string): boolean {
+  return (
+    p.startsWith('navigation.') ||
+    p.startsWith('environment.') ||
+    p.startsWith('steering.')
+  )
+}
+
+interface SignalKDelta {
+  updates?: Array<{
+    values?: Array<{ path: string; value: unknown }>
+  }>
+}
+
+const seen: Record<string, unknown> = {}
+const ws = new WebSocket(url + '?subscribe=none', { rejectUnauthorized: false })
+
+ws.on('open', () => {
+  ws.send(
+    JSON.stringify({
+      context: 'vessels.self',
+      subscribe: [{ path: '*' }]
+    })
+  )
+  setTimeout(() => ws.close(), captureSeconds * 1000)
+})
+
+ws.on('message', (data: Buffer) => {
+  let parsed: SignalKDelta
+  try {
+    parsed = JSON.parse(data.toString())
+  } catch {
+    return
+  }
+  for (const u of parsed.updates ?? []) {
+    for (const v of u.values ?? []) {
+      if (v.path && shouldInclude(v.path) && !(v.path in seen)) {
+        seen[v.path] = v.value
+      }
+    }
+  }
+})
+
+ws.on('close', () => {
+  fs.writeFileSync(
+    outFile,
+    JSON.stringify(
+      {
+        scenario: scenarioName,
+        capturedAt: new Date().toISOString(),
+        paths: seen
+      },
+      null,
+      2
+    )
+  )
+  console.log('saved ' + Object.keys(seen).length + ' paths to ' + outFile)
+  process.exit(0)
+})
+
+ws.on('error', (e: Error) => {
+  console.error('ERR ' + e.message)
+  process.exit(1)
+})

--- a/scripts/probe-snapshot.ts
+++ b/scripts/probe-snapshot.ts
@@ -1,0 +1,156 @@
+/*
+ * Live-snapshot probe.
+ *
+ * Loads a captured Signal K deltastream snapshot from JSON, wires every
+ * sentence encoder up to mocked streams, pushes the snapshot values, and
+ * reports per-encoder: emitted NMEA sentences and silent paths.
+ *
+ * Push ordering matters because of `.debounceImmediate(20)` in index.ts:
+ * the combined stream fires once and ignores subsequent values for 20 ms.
+ * So we push "context" paths (those that have a default in the encoder)
+ * BEFORE "trigger" paths (those without a default), so the first fire
+ * already has the real context values.
+ *
+ * Run: npx tsx scripts/probe-snapshot.ts <snapshot.json>
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+import * as Bacon from 'baconjs'
+
+interface Snapshot {
+  scenario: string
+  paths: Record<string, unknown>
+}
+
+const snapshotFile = process.argv[2]
+if (!snapshotFile) {
+  console.error('Usage: probe-snapshot.ts <snapshot.json>')
+  process.exit(2)
+}
+const snapshot = JSON.parse(
+  fs.readFileSync(path.resolve(snapshotFile), 'utf8')
+) as Snapshot
+
+console.log('\n=== Probing snapshot: ' + snapshot.scenario + ' ===')
+console.log('Captured paths: ' + Object.keys(snapshot.paths).length + '\n')
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const factory = require('../src/index')
+
+interface MockApp {
+  streambundle: { getSelfStream: (p: string) => Bacon.Bus<unknown> }
+  emit: (n: string, v: unknown) => void
+  debug: (m: unknown) => void
+  reportOutputMessages?: (n: number) => void
+}
+
+interface PerEncoder {
+  name: string
+  subscribed: string[]
+  emitted: string[]
+  silentPaths: string[]
+  errors: string[]
+}
+
+function probeEncoder(name: string): Promise<PerEncoder> {
+  const streams: Record<string, Bacon.Bus<unknown>> = {}
+  const emitted: string[] = []
+  const errors: string[] = []
+  const app: MockApp = {
+    streambundle: {
+      getSelfStream: (p: string): Bacon.Bus<unknown> => {
+        if (!streams[p]) streams[p] = new Bacon.Bus<unknown>()
+        return streams[p]!
+      }
+    },
+    emit: (n: string, v: unknown): void => {
+      if (n === 'nmea0183out') emitted.push(String(v))
+    },
+    debug: (m: unknown): void => {
+      const s = String(m)
+      if (s.includes('not converting') || s.includes('skip')) errors.push(s)
+    }
+  }
+  const plugin = factory(app)
+  if (!plugin.sentences[name]) {
+    return Promise.resolve({
+      name,
+      subscribed: [],
+      emitted: [],
+      silentPaths: [],
+      errors: ['encoder not loaded']
+    })
+  }
+  const encoder = plugin.sentences[name]
+  plugin.start({ [name]: true })
+
+  // Order pushes so context paths (those with a default) go first; the
+  // last push (a trigger path with no default) fires the combined stream
+  // with all context already populated.
+  const keys = encoder.keys as string[]
+  const defaults = (encoder.defaults || []) as unknown[]
+  const contextPaths = keys.filter(
+    (_k: string, i: number) => defaults[i] !== undefined
+  )
+  const triggerPaths = keys.filter(
+    (_k: string, i: number) => defaults[i] === undefined
+  )
+  const pushOrder = [...contextPaths, ...triggerPaths]
+
+  const subscribed = Object.keys(streams)
+  const silentPaths: string[] = []
+  for (const p of pushOrder) {
+    if (p in snapshot.paths) {
+      streams[p]!.push(snapshot.paths[p])
+    } else if (defaults[keys.indexOf(p)] === undefined) {
+      // Trigger path missing - encoder cannot fire
+      silentPaths.push(p)
+    }
+  }
+  return new Promise<PerEncoder>((resolve) => {
+    setTimeout(() => {
+      try {
+        plugin.stop()
+      } catch {}
+      resolve({ name, subscribed, emitted, silentPaths, errors })
+    }, 100)
+  })
+}
+
+async function main(): Promise<void> {
+  const tmpApp: MockApp = {
+    streambundle: { getSelfStream: () => new Bacon.Bus<unknown>() },
+    emit: () => {},
+    debug: () => {}
+  }
+  const tmpPlugin = factory(tmpApp)
+  const encoderNames = Object.keys(tmpPlugin.sentences).sort()
+
+  const results: PerEncoder[] = []
+  for (const name of encoderNames) {
+    // eslint-disable-next-line no-await-in-loop
+    const r = await probeEncoder(name)
+    results.push(r)
+  }
+
+  console.log('=== Per-encoder result ===')
+  for (const r of results) {
+    if (r.emitted.length > 0) {
+      console.log(
+        '  OK  ' + r.name.padEnd(12) + ' -> ' + r.emitted[r.emitted.length - 1]
+      )
+    } else {
+      const reason =
+        r.silentPaths.length > 0
+          ? 'silent paths: ' + r.silentPaths.join(', ')
+          : r.errors.length > 0
+            ? 'errors: ' + r.errors.join('; ')
+            : 'no emission'
+      console.log(
+        '  --  ' + r.name.padEnd(12) + ' -> DID NOT EMIT (' + reason + ')'
+      )
+    }
+  }
+}
+
+main().then(() => process.exit(0))

--- a/src/sentences/APB-true.ts
+++ b/src/sentences/APB-true.ts
@@ -1,47 +1,16 @@
 /*
-      ------------------------------------------------------------------------------
-                                       13    15
-      1 2 3   4 5 6 7 8   9 10   11  12|   14|
-      | | |   | | | | |   | |    |   | |   | |
-      $--APB,A,A,x.x,a,N,A,A,x.x,a,c--c,x.x,a,x.x,a*hh<CR><LF>
-      ------------------------------------------------------------------------------
+$--APB,A,A,x.x,a,N,A,A,x.x,a,c--c,x.x,a,x.x,a*hh
 
-      Field Number:
+Same field layout as APB but all three bearing pairs are reported True. For
+autopilots that require Magnetic bearings use APB.
 
-      1. Status
-      V = LORAN-C Blink or SNR warning
-      V = general warning flag or other navigation systems when a reliable
-      fix is not available
-      2. Status
-      V = Loran-C Cycle Lock warning flag
-      A = OK or not used
-      3. Cross Track Error Magnitude
-      4. Direction to steer, L or R
-      5. Cross Track Units, N = Nautical Miles
-      6. Status
-      A = Arrival Circle Entered
-      7. Status
-      A = Perpendicular passed at waypoint
-      8. Bearing origin to destination
-      9. M = Magnetic, T = True
-      10. Destination Waypoint ID
-      11. Bearing, present position to Destination
-      12. M = Magnetic, T = True
-      13. Heading to steer to destination waypoint
-      14. M = Magnetic, T = True
-      15. Checksum
-
-      All three bearing pairs use True.  For autopilots that require
-      Magnetic bearings use APB instead.
-
-      Example: $GPAPB,A,A,0.10,R,N,V,V,011,T,DEST,011,T,011,T*82
-    */
+Waypoint ID (field 10) follows the BWC pattern: prefer `nextPoint.name`, then
+synthesize "WP <pointIndex+1>" from `activeRoute.pointIndex`, else empty.
+*/
 import * as nmea from '../nmea'
+import { generateWaypointName } from '../waypointNameGenerator'
+import type { ActiveRoute, NextPoint } from '../waypointNameGenerator'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
-
-interface NextPoint {
-  name?: string
-}
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {
@@ -51,20 +20,18 @@ export default function (_app: SignalKApp): SentenceEncoder {
       'navigation.course.calcValues.crossTrackError',
       'navigation.course.calcValues.bearingTrackTrue',
       'navigation.course.calcValues.bearingTrue',
-      'navigation.course.nextPoint'
+      'navigation.course.nextPoint',
+      'navigation.course.activeRoute'
     ],
-    // nextPoint defaults to {} so APB still fires when only calcValues are
-    // available (the common case today). Once signalk-server populates
-    // nextPoint.name (see SignalK/signalk-server#2595, SignalK/specification#676),
-    // the waypoint identifier will flow through automatically.
-    defaults: [undefined, undefined, undefined, {}],
+    defaults: [undefined, undefined, undefined, {}, {}],
     f: function (
       xte: number,
       originToDest: number,
       bearingTrue: number,
-      nextPoint: NextPoint | null | undefined
+      nextPoint: NextPoint | null | undefined,
+      activeRoute: ActiveRoute | null | undefined
     ): string {
-      const waypointId = (nextPoint && nextPoint.name) || ''
+      const waypointId = generateWaypointName(nextPoint, activeRoute)
       return nmea.toSentence([
         '$IIAPB',
         'A',

--- a/src/sentences/APB.ts
+++ b/src/sentences/APB.ts
@@ -1,48 +1,32 @@
 /*
-      ------------------------------------------------------------------------------
-                                       13    15
-      1 2 3   4 5 6 7 8   9 10   11  12|   14|
-      | | |   | | | | |   | |    |   | |   | |
-      $--APB,A,A,x.x,a,N,A,A,x.x,a,c--c,x.x,a,x.x,a*hh<CR><LF>
-      ------------------------------------------------------------------------------
+$--APB,A,A,x.x,a,N,A,A,x.x,a,c--c,x.x,a,x.x,a*hh
 
-      Field Number:
+Field 1:  Status (A = OK, V = warning)
+Field 2:  Status (A = OK, V = LORAN-C cycle-lock warning)
+Field 3:  Cross Track Error magnitude (NM)
+Field 4:  Direction to steer (L or R)
+Field 5:  Cross-track units (N = nautical miles)
+Field 6:  Status: A = Arrival Circle Entered
+Field 7:  Status: A = Perpendicular passed at waypoint
+Field 8:  Bearing origin to destination
+Field 9:  M = Magnetic, T = True
+Field 10: Destination Waypoint ID
+Field 11: Bearing, present position to destination
+Field 12: M = Magnetic, T = True
+Field 13: Heading-to-steer to destination waypoint
+Field 14: M = Magnetic, T = True
 
-      1. Status
-      V = LORAN-C Blink or SNR warning
-      V = general warning flag or other navigation systems when a reliable
-      fix is not available
-      2. Status
-      V = Loran-C Cycle Lock warning flag
-      A = OK or not used
-      3. Cross Track Error Magnitude
-      4. Direction to steer, L or R
-      5. Cross Track Units, N = Nautical Miles
-      6. Status
-      A = Arrival Circle Entered
-      7. Status
-      A = Perpendicular passed at waypoint
-      8. Bearing origin to destination
-      9. M = Magnetic, T = True
-      10. Destination Waypoint ID
-      11. Bearing, present position to Destination
-      12. M = Magnetic, T = True
-      13. Heading to steer to destination waypoint
-      14. M = Magnetic, T = True
-      15. Checksum
+All three bearing pairs are reported Magnetic, computed from the True bearings
+and `navigation.magneticVariation`. For autopilots that require True bearings
+use APB-true.
 
-      All three bearing pairs use Magnetic, computed from True bearings
-      and magneticVariation.  For autopilots that require True bearings
-      use APB-true instead.
-
-      Example: $GPAPB,A,A,0.10,R,N,V,V,011,M,DEST,011,M,011,M*82
-    */
+Waypoint ID (field 10) follows the BWC pattern: prefer `nextPoint.name`, then
+synthesize "WP <pointIndex+1>" from `activeRoute.pointIndex`, else empty.
+*/
 import * as nmea from '../nmea'
+import { generateWaypointName } from '../waypointNameGenerator'
+import type { ActiveRoute, NextPoint } from '../waypointNameGenerator'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
-
-interface NextPoint {
-  name?: string
-}
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {
@@ -53,17 +37,19 @@ export default function (_app: SignalKApp): SentenceEncoder {
       'navigation.course.calcValues.bearingTrackTrue',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.nextPoint',
-      'navigation.magneticVariation'
+      'navigation.magneticVariation',
+      'navigation.course.activeRoute'
     ],
-    defaults: [undefined, undefined, undefined, {}, undefined],
+    defaults: [undefined, undefined, undefined, {}, undefined, {}],
     f: function (
       xte: number,
       originToDest: number,
       bearingTrue: number,
       nextPoint: NextPoint | null | undefined,
-      magneticVariation: number
+      magneticVariation: number,
+      activeRoute: ActiveRoute | null | undefined
     ): string {
-      const waypointId = (nextPoint && nextPoint.name) || ''
+      const waypointId = generateWaypointName(nextPoint, activeRoute)
       const bearingOriginToDestMag = nmea.radsToPositiveDeg(
         nmea.fixAngle(originToDest - magneticVariation)
       )

--- a/src/sentences/BWC.ts
+++ b/src/sentences/BWC.ts
@@ -21,7 +21,7 @@ Field Number:
 13. Checksum
 
 Signal K source paths verified by subscribing to the live deltastream of a
-running signalk-server (openplotter) with an active route:
+running signalk-server with an active route:
 
   - navigation.datetime                            -> ISO datetime
   - navigation.course.nextPoint                    -> {type, position, [name]}
@@ -36,10 +36,13 @@ VesselPosition) and `position` regardless of the active calculation method.
 The parallel `navigation.courseGreatCircle.nextPoint` is silent on the
 deltastream (only its leaf children emit) and is NOT what to subscribe to.
 
-Waypoint name resolution (field 12):
+Waypoint name (field 12) is resolved by `generateWaypointName`, shared with
+RMB/APB/APB-true:
   1. nextPoint.name when SignalK/signalk-server#2608 lands
   2. "WP <pointIndex+1>" when a route is active (e.g. "WP 1", "WP 2")
-  3. empty when the destination is a Location-type point with no route
+  3. "WP 1" as a single-point default. BWC is used for both active-route
+     and "goto" navigation, so a sensible identifier is preferred over an
+     empty field that some chartplotters reject.
 
 Bearing values reflect the calcMethod set in signalk-server (GreatCircle or
 Rhumbline). For typical sailing distances the difference is negligible; if
@@ -47,26 +50,9 @@ you need strictly great-circle BWC, set the server's course calc method to
 GreatCircle.
 */
 import * as nmea from '../nmea'
+import { generateWaypointName } from '../waypointNameGenerator'
+import type { ActiveRoute, NextPoint } from '../waypointNameGenerator'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
-
-interface NextPoint {
-  type?: string
-  position?: { latitude?: number; longitude?: number }
-  name?: string
-}
-
-interface ActiveRoute {
-  href?: string | null
-  name?: string | null
-  pointIndex?: number | null
-  pointTotal?: number | null
-}
-
-// NMEA0183 reserves these characters for sentence framing. A waypoint name
-// containing them would inject fields, forge a checksum boundary, or break
-// out of the sentence entirely.
-const NMEA_RESERVED = /[,*$\r\n]/g
-const MAX_WAYPOINT_ID_LEN = 20
 
 function inLatRange(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v) && v >= -90 && v <= 90
@@ -77,24 +63,6 @@ function inLonRange(v: unknown): v is number {
   // as +180 only). Catching here rather than letting it throw downstream
   // keeps emission failures uniform with the other validation paths.
   return typeof v === 'number' && Number.isFinite(v) && v > -180 && v <= 180
-}
-
-function deriveWaypointId(
-  nextPoint: NextPoint,
-  activeRoute: ActiveRoute
-): string {
-  // Prefer the per-waypoint name once SignalK publishes it.
-  if (typeof nextPoint.name === 'string' && nextPoint.name.length > 0) {
-    return nextPoint.name
-  }
-  // Synthesize "WP N" from the active route's 1-based point index. Works
-  // for both single- and multi-point routes; chartplotters use this field
-  // primarily to distinguish successive waypoints, which "WP 1" / "WP 2"
-  // does without leaking a potentially noisy route name into the sentence.
-  if (typeof activeRoute.pointIndex === 'number') {
-    return `WP ${activeRoute.pointIndex + 1}`
-  }
-  return ''
 }
 
 export default function (_app: SignalKApp): SentenceEncoder {
@@ -154,13 +122,7 @@ export default function (_app: SignalKApp): SentenceEncoder {
         ? nmea.radsToPositiveDeg(bearingMagnetic as number)
         : undefined
 
-      const rawId = deriveWaypointId(nextPoint, activeRoute ?? {})
-      const sanitized = rawId.replace(NMEA_RESERVED, '')
-      let waypointId = sanitized
-      if (waypointId.length > MAX_WAYPOINT_ID_LEN) {
-        waypointId = waypointId.slice(0, MAX_WAYPOINT_ID_LEN)
-        _app.debug('BWC: truncated waypoint name to 20 characters')
-      }
+      const waypointId = generateWaypointName(nextPoint, activeRoute)
 
       return nmea.toSentence([
         '$IIBWC',

--- a/src/sentences/RMB.ts
+++ b/src/sentences/RMB.ts
@@ -23,14 +23,19 @@ Field Number:
 13. Arrival Status, A = Arrival Circle Entered
 14. FAA mode indicator (NMEA 2.3 and later)
 15. Checksum
+
+Field 4 (TO Waypoint ID) is derived via generateWaypointName: prefer nextPoint.name,
+synthesize "WP <pointIndex+1>" from activeRoute.pointIndex, else empty. Field 5
+(FROM) uses previousPoint.name when available -- in practice signalk-server
+emits previousPoint as a VesselPosition without a name, so this falls back to
+empty in direct-to-point and route-by-name cases.
 */
 import * as nmea from '../nmea'
+import { generateWaypointName } from '../waypointNameGenerator'
+import type { ActiveRoute, NextPoint } from '../waypointNameGenerator'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
 
-interface Waypoint {
-  name?: string
-  position?: { latitude?: number; longitude?: number }
-}
+type PreviousPoint = NextPoint
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {
@@ -42,29 +47,26 @@ export default function (_app: SignalKApp): SentenceEncoder {
       'navigation.course.calcValues.distance',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.calcValues.velocityMadeGood',
-      'navigation.course.previousPoint'
+      'navigation.course.previousPoint',
+      'navigation.course.activeRoute'
     ],
-    // nextPoint and previousPoint default to {} so RMB still fires when only
-    // calcValues are available (the common case today). Once signalk-server
-    // populates nextPoint.name / previousPoint.name (see
-    // SignalK/signalk-server#2595, SignalK/specification#676), the waypoint
-    // identifiers will flow through automatically.
-    defaults: [undefined, {}, undefined, undefined, undefined, {}],
+    defaults: [undefined, {}, undefined, undefined, undefined, {}, {}],
     f: function (
       crossTrackError: number,
-      wp: Waypoint,
+      wp: NextPoint,
       wpDistance: number,
       bearingTrue: number,
       vmg: number,
-      prevWp: Waypoint | null | undefined
+      prevWp: PreviousPoint | null | undefined,
+      activeRoute: ActiveRoute | null | undefined
     ): string | undefined {
-      const destinationId = (wp && wp.name) || ''
-      const originId = (prevWp && prevWp.name) || ''
-      const wpLat = wp.position?.latitude
-      const wpLon = wp.position?.longitude
+      const wpLat = wp?.position?.latitude
+      const wpLon = wp?.position?.longitude
       if (typeof wpLat !== 'number' || typeof wpLon !== 'number') {
         return undefined
       }
+      const destinationId = generateWaypointName(wp, activeRoute)
+      const originId = generateWaypointName(prevWp, activeRoute)
       return nmea.toSentence([
         '$IIRMB',
         'A',

--- a/src/sentences/XTE-GC.ts
+++ b/src/sentences/XTE-GC.ts
@@ -1,15 +1,25 @@
 /*
-Cross-track error:
+Cross-track error (subscribes alongside XTE for legacy config compat).
+
 $IIXTE,A,A,x.x,a,N,A*hh
  I_Cross-track error in miles, L= left, R= right
- */
+
+Historically this encoder subscribed to `navigation.courseGreatCircle.crossTrackError`
+to provide a great-circle-specific XTE. Modern signalk-server (>= 2.x)
+publishes a single cross-track error at `navigation.course.calcValues.cross
+TrackError` which reflects whichever calcMethod is configured server-side
+(GreatCircle or Rhumbline), so this encoder now subscribes to that same
+path. It is functionally equivalent to the regular XTE encoder; both are
+kept so existing user configs that enable `XTE-GC: true` continue to emit.
+Enable only one to avoid duplicate sentences on the bus.
+*/
 import * as nmea from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
 
 export default function (_app: SignalKApp): SentenceEncoder<[number]> {
   return {
-    title: 'XTE - Cross-track error (w.r.t. Great Circle)',
-    keys: ['navigation.courseGreatCircle.crossTrackError'],
+    title: 'XTE - Cross-track error (w.r.t. server-configured calcMethod)',
+    keys: ['navigation.course.calcValues.crossTrackError'],
     f: function (crossTrackError: number): string {
       return nmea.toSentence([
         '$IIXTE',

--- a/src/waypointNameGenerator.ts
+++ b/src/waypointNameGenerator.ts
@@ -1,0 +1,89 @@
+/**
+ * Generates a NMEA0183 waypoint identifier from Signal K's `nextPoint` /
+ * `previousPoint` and `activeRoute` deltas. Used by RMB (fields 4 and 5),
+ * APB (field 10), APB-true (field 10), and BWC (field 12).
+ *
+ * Resolution order:
+ *   1. `point.name`              -- once signalk-server populates this
+ *      in the delta stream (see SignalK/signalk-server#2608).
+ *   2. `synthesizeFallbackName()` -- pre-2608 fallback that mirrors the
+ *      defaults the upstream PR applies, so behavior is consistent both
+ *      before and after that PR ships. REMOVE the fallback once #2608
+ *      is released and we can rely on `point.name` always being set.
+ *
+ * NMEA0183 reserves a few framing characters; we strip them defensively
+ * in case `point.name` ever contains them.
+ */
+
+export interface CoursePoint {
+  type?: string
+  name?: string
+  position?: { latitude?: number; longitude?: number }
+  href?: string | null
+}
+
+export interface ActiveRoute {
+  href?: string | null
+  name?: string | null
+  pointIndex?: number | null
+  pointTotal?: number | null
+}
+
+// Preserved for backward compatibility with callers that imported the
+// original `NextPoint` name; the shape is identical to CoursePoint.
+export type NextPoint = CoursePoint
+
+const NMEA_RESERVED = /[,*$\r\n]/g
+const MAX_WAYPOINT_NAME_LEN = 20
+
+export function generateWaypointName(
+  point: CoursePoint | null | undefined,
+  activeRoute: ActiveRoute | null | undefined
+): string {
+  const p = point ?? {}
+  if (typeof p.name === 'string' && p.name.length > 0) {
+    return sanitize(p.name)
+  }
+  return sanitize(synthesizeFallbackName(p, activeRoute ?? {}))
+}
+
+/**
+ * Pre-#2608 fallback: synthesize a default name from the point type.
+ * Mirrors signalk-server's CourseAPI defaults so the NMEA output stays
+ * consistent before and after #2608 lands:
+ *
+ *   RoutePoint     -> "WP<pointIndex+1>" (e.g. "WP1", "WP2", ...)
+ *   Waypoint       -> "WP1"   (single-point goto-waypoint)
+ *   Location       -> "DP"    (direct-to-position)
+ *   VesselPosition -> "VP"    (previousPoint at start of any goto)
+ *   (anything else)-> "WP1"   (last-ditch default matching upstream)
+ *
+ * REMOVE this function once SignalK/signalk-server#2608 is released and
+ * point.name is reliably populated in the delta stream.
+ */
+function synthesizeFallbackName(
+  point: CoursePoint,
+  activeRoute: ActiveRoute
+): string {
+  if (point.type === 'RoutePoint') {
+    if (typeof activeRoute.pointIndex === 'number') {
+      return `WP${activeRoute.pointIndex + 1}`
+    }
+    return 'WP1'
+  }
+  if (point.type === 'Location') {
+    return 'DP'
+  }
+  if (point.type === 'VesselPosition') {
+    return 'VP'
+  }
+  // Waypoint or unknown type
+  return 'WP1'
+}
+
+function sanitize(name: string): string {
+  const stripped = name.replace(NMEA_RESERVED, '')
+  return stripped.length > MAX_WAYPOINT_NAME_LEN
+    ? stripped.slice(0, MAX_WAYPOINT_NAME_LEN)
+    : stripped
+}

--- a/test/APB-true.ts
+++ b/test/APB-true.ts
@@ -128,16 +128,17 @@ describe('APB-true', function () {
     })
   })
 
-  it('uses empty field 10 when nextPoint has no name', (done) => {
-    // Route points typically have no name (just type: "RoutePoint" and a
-    // position). NMEA allows empty fields, so field 10 should be empty rather
-    // than a meaningless placeholder like "00".
+  it('falls back to "WP1" when nextPoint has no name and no route is active', (done) => {
+    // Route points and direct-to-position both arrive without a name (just a
+    // type and position). Empty field 10 confuses some chartplotters, so the
+    // generator emits "WP1" as a sensible single-point default. With an
+    // active multi-point route, "WP <pointIndex+1>" is used instead.
     const onEmit = (_event: string, value: unknown): void => {
       const fields = parseApb(value as string)
       assert.equal(
         fields.waypointId,
-        '',
-        'field 10 should be empty when no waypoint name is available'
+        'WP1',
+        'field 10 should default to "WP1" when no waypoint name is available'
       )
       done()
     }

--- a/test/BWC-integration.ts
+++ b/test/BWC-integration.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import pluginFactory from '../src/index'
 import type { SignalKPlugin } from '../src/types/plugin'
 
-// Live snapshot captured from openplotter's deltastream (vessel sailing
+// Live snapshot captured from signalk-server's deltastream (vessel sailing
 // near Marsh Harbour, Bahamas, 9° W magnetic variation, 3-point route
 // "TO DELETE" active, currently heading to point 1 of 3).
 const LIVE_SNAPSHOT = {
@@ -30,7 +30,7 @@ const LIVE_SNAPSHOT = {
   bearingMagnetic: 5.729787364152641,
   distance: 127.040711001917,
   expectedSentence:
-    '$IIBWC,193222.00,2632.8570,N,07703.5953,W,337.5,T,328.3,M,0.07,N,WP 1*0E'
+    '$IIBWC,193222.00,2632.8570,N,07703.5953,W,337.5,T,328.3,M,0.07,N,WP1*2E'
 } as const
 
 describe('BWC Integration', function () {
@@ -114,7 +114,7 @@ describe('BWC Integration', function () {
     assert.equal(fields[11], 'N')
     assert.equal(
       fields[12],
-      'WP 1',
+      'WP1',
       'waypoint ID synthesized as "WP <pointIndex+1>"'
     )
   })

--- a/test/BWC.ts
+++ b/test/BWC.ts
@@ -6,7 +6,7 @@ type AnyApp = ReturnType<typeof createAppWithPlugin>
 
 /**
  * Real navigation snapshots captured from the live deltastream of a running
- * signalk-server (openplotter sailing near Marsh Harbour, Bahamas, 9° west
+ * signalk-server (sailing near Marsh Harbour, Bahamas, 9° west
  * magnetic variation, 3-point route active "TO DELETE").
  *
  * Kept verbatim so the test fixture documents the exact wire shape the
@@ -34,7 +34,7 @@ const LIVE_SNAPSHOT_1 = {
   bearingMagnetic: 5.729787364152641, // 328.3° magnetic
   distance: 127.040711001917, // 0.07 NM
   expectedSentence:
-    '$IIBWC,193222.00,2632.8570,N,07703.5953,W,337.5,T,328.3,M,0.07,N,WP 1*0E'
+    '$IIBWC,193222.00,2632.8570,N,07703.5953,W,337.5,T,328.3,M,0.07,N,WP1*2E'
 } as const
 
 interface NextPointArg {
@@ -140,7 +140,7 @@ function xorChecksum(body: string): string {
 }
 
 describe('BWC', function () {
-  describe('real-world snapshot from openplotter', function () {
+  describe('real-world snapshot from signalk-server', function () {
     it('reproduces the exact sentence captured from a live 3-point route', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
         assert.equal(value, LIVE_SNAPSHOT_1.expectedSentence)
@@ -225,17 +225,17 @@ describe('BWC', function () {
   describe('waypoint ID derivation (field 12)', function () {
     it('emits "WP <pointIndex+1>" for the first point of a multi-point route', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        // pointIndex=0 → "WP 1"
-        assert.equal(parseBwc(value as string).fields.waypointId, 'WP 1')
+        // pointIndex=0 → "WP1"
+        assert.equal(parseBwc(value as string).fields.waypointId, 'WP1')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
       pushBwcStreams(app, {})
     })
 
-    it('emits "WP 3" when pointIndex advances to the third leg', (done) => {
+    it('emits "WP3" when pointIndex advances to the third leg', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.waypointId, 'WP 3')
+        assert.equal(parseBwc(value as string).fields.waypointId, 'WP3')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
@@ -244,9 +244,9 @@ describe('BWC', function () {
       })
     })
 
-    it('emits "WP 1" for a single-point route (does not use the route name)', (done) => {
+    it('emits "WP1" for a single-point route (does not use the route name)', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.waypointId, 'WP 1')
+        assert.equal(parseBwc(value as string).fields.waypointId, 'WP1')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
@@ -270,9 +270,9 @@ describe('BWC', function () {
       })
     })
 
-    it('emits empty waypoint ID for a Location-type destination with no route', (done) => {
+    it('emits "DP" for a Location-type destination with no route (goto navigation)', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.waypointId, '')
+        assert.equal(parseBwc(value as string).fields.waypointId, 'DP')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
@@ -285,9 +285,9 @@ describe('BWC', function () {
       })
     })
 
-    it('emits empty waypoint ID when activeRoute stream is the {} default', (done) => {
+    it('emits "DP" when activeRoute stream is the {} default and nextPoint is a Location', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.waypointId, '')
+        assert.equal(parseBwc(value as string).fields.waypointId, 'DP')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')

--- a/test/RMB.ts
+++ b/test/RMB.ts
@@ -130,18 +130,22 @@ describe('RMB', function () {
     })
   })
 
-  it('uses empty fields when waypoint objects have no name', (done) => {
+  it('synthesizes type-specific defaults when names are missing (DP/VP/WP1)', (done) => {
+    // Mirrors signalk-server #2608's defaults so behavior is consistent
+    // before and after that PR ships:
+    //   nextPoint type=Location, no name      -> "DP" (Destination Position)
+    //   previousPoint type=VesselPosition     -> "VP"
     const onEmit = (_event: string, value: unknown): void => {
       const fields = parseRmb(value as string)
       assert.equal(
         fields.destinationId,
-        '',
-        'field 4 should be empty when no waypoint name is available'
+        'DP',
+        'field 4 should be "DP" for a Location-type destination'
       )
       assert.equal(
         fields.originId,
-        '',
-        'field 5 should be empty when no waypoint name is available'
+        'VP',
+        'field 5 should be "VP" for a VesselPosition origin'
       )
       done()
     }
@@ -149,11 +153,11 @@ describe('RMB', function () {
     pushRmbStreams(app, {
       nextPoint: {
         position: { latitude: 48.1173, longitude: 11.5167 },
-        type: 'RoutePoint'
+        type: 'Location'
       },
       previousPoint: {
         position: { latitude: 47.3769, longitude: 8.5417 },
-        type: 'RoutePoint'
+        type: 'VesselPosition'
       }
     })
   })

--- a/test/live-snapshots.ts
+++ b/test/live-snapshots.ts
@@ -1,0 +1,277 @@
+/*
+ * Live-snapshot regression tests.
+ *
+ * The scenario data inlined below is extracted from deltastream
+ * snapshots captured against a running signalk-server (2.26.0) and
+ * covers the three navigation modes a chartplotter / autopilot user
+ * can be in:
+ *
+ *   1. navigate-to-point     - direct to a position, no waypoint, no route
+ *   2. navigate-to-waypoint  - direct to a saved waypoint, no route
+ *   3. active-route          - multi-point route active, currently at point 1
+ *
+ * Each scenario asserts the routing sentences (RMB, APB, APB-true, XTE)
+ * against the captured state. Pushes are ordered context-first (paths
+ * with a default in the encoder) then trigger-last so the combined
+ * stream's first fire already has all context populated.
+ *
+ * Full snapshots are kept under test/snapshots/ for diagnostic re-runs
+ * via scripts/probe-snapshot.ts; new scenarios can be captured with
+ * scripts/capture-snapshot.ts. Only the routing-relevant subset of
+ * paths is inlined here so the tests are self-contained.
+ */
+import * as Bacon from 'baconjs'
+import * as assert from 'assert'
+
+interface Scenario {
+  name: string
+  paths: Record<string, unknown>
+}
+
+const SCENARIO_NO_WAYPOINT: Scenario = {
+  name: 'navigate-to-point (no waypoint, no route)',
+  paths: {
+    'navigation.course.calcValues.crossTrackError': 2.5441476328008386,
+    'navigation.course.calcValues.bearingTrackTrue': 4.831171944671482,
+    'navigation.course.calcValues.bearingTrue': 4.823602533829535,
+    'navigation.course.calcValues.distance': 336.1154538639113,
+    'navigation.course.calcValues.velocityMadeGood': 0,
+    'navigation.course.nextPoint': {
+      position: {
+        latitude: 26.54696714586578,
+        longitude: -77.06287980079651
+      },
+      type: 'Location'
+    },
+    'navigation.course.previousPoint': {
+      position: {
+        latitude: 26.546606666666666,
+        longitude: -77.05950333333334
+      },
+      type: 'VesselPosition'
+    },
+    'navigation.course.activeRoute': null,
+    'navigation.magneticVariation': -0.16089135395421264
+  }
+}
+
+const SCENARIO_WAYPOINT: Scenario = {
+  name: 'navigate-to-waypoint (saved waypoint, no route)',
+  paths: {
+    'navigation.course.calcValues.crossTrackError': -0.20313368473614887,
+    'navigation.course.calcValues.bearingTrackTrue': 4.827445107318298,
+    'navigation.course.calcValues.bearingTrue': 4.828220941657066,
+    'navigation.course.calcValues.distance': 261.8239416044419,
+    'navigation.course.calcValues.velocityMadeGood': 0,
+    'navigation.course.nextPoint': {
+      position: {
+        latitude: 26.547003799661532,
+        longitude: -77.06213951110841
+      },
+      href: '/resources/waypoints/c9dc41b2-1bce-4e7d-80f2-882aca7a3eae',
+      type: 'Waypoint'
+    },
+    'navigation.course.previousPoint': {
+      position: {
+        latitude: 26.546733333333332,
+        longitude: -77.05952333333333
+      },
+      type: 'VesselPosition'
+    },
+    'navigation.course.activeRoute': null,
+    'navigation.magneticVariation': -0.16089135395421264
+  }
+}
+
+const SCENARIO_ROUTE: Scenario = {
+  name: 'active multi-point route, at point 1 of 3',
+  paths: {
+    'navigation.course.calcValues.crossTrackError': 0.18524218386861044,
+    'navigation.course.calcValues.bearingTrackTrue': 4.682498620978,
+    'navigation.course.calcValues.bearingTrue': 4.682038884004606,
+    'navigation.course.calcValues.distance': 402.9308132880701,
+    'navigation.course.calcValues.velocityMadeGood': 0,
+    'navigation.course.nextPoint': {
+      type: 'RoutePoint',
+      position: {
+        latitude: 26.54661003894277,
+        longitude: -77.06357717514038
+      }
+    },
+    'navigation.course.previousPoint': {
+      position: {
+        latitude: 26.546718333333335,
+        longitude: -77.05952833333333
+      },
+      type: 'VesselPosition'
+    },
+    'navigation.course.activeRoute': {
+      href: '/resources/routes/c1551d44-65dc-409d-b09a-7482202cc2a1',
+      name: 'Route 20260508 (2)',
+      reverse: false,
+      pointIndex: 0,
+      pointTotal: 3
+    },
+    'navigation.magneticVariation': -0.16089135395421264
+  }
+}
+
+interface MockApp {
+  streambundle: { getSelfStream: (p: string) => Bacon.Bus<unknown> }
+  emit: (n: string, v: unknown) => void
+  debug: (m: unknown) => void
+  reportOutputMessages?: (n: number) => void
+}
+
+function runEncoder(
+  encoderName: string,
+  scenario: Scenario,
+  delayMs: number = 80
+): Promise<{ emissions: string[] }> {
+  const streams: Record<string, Bacon.Bus<unknown>> = {}
+  const emissions: string[] = []
+  const app: MockApp = {
+    streambundle: {
+      getSelfStream: (p: string): Bacon.Bus<unknown> => {
+        if (!streams[p]) streams[p] = new Bacon.Bus<unknown>()
+        return streams[p]!
+      }
+    },
+    emit: (n: string, v: unknown): void => {
+      if (n === 'nmea0183out') emissions.push(String(v))
+    },
+    debug: (): void => {}
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const factory = require('../src/index')
+  const plugin = factory(app)
+  const encoder = plugin.sentences[encoderName]
+  if (!encoder) {
+    throw new Error('encoder not registered: ' + encoderName)
+  }
+  plugin.start({ [encoderName]: true })
+
+  const keys = encoder.keys as string[]
+  const defaults = (encoder.defaults || []) as unknown[]
+  // Push context paths (with a default) first, then trigger paths (no
+  // default). The combined stream first fire then has all context
+  // already populated.
+  const order = [
+    ...keys.filter((_k, i) => defaults[i] !== undefined),
+    ...keys.filter((_k, i) => defaults[i] === undefined)
+  ]
+  for (const p of order) {
+    if (p in scenario.paths) {
+      streams[p]!.push(scenario.paths[p])
+    }
+  }
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      plugin.stop()
+      resolve({ emissions })
+    }, delayMs)
+  })
+}
+
+describe('live signalk-server snapshots: routing sentences', function () {
+  this.timeout(5000)
+
+  describe('Scenario 1: ' + SCENARIO_NO_WAYPOINT.name, function () {
+    const s = SCENARIO_NO_WAYPOINT
+
+    it('RMB field 4 contains "DP"', async function () {
+      const { emissions } = await runEncoder('RMB', s)
+      assert.ok(emissions.length > 0, 'RMB must emit')
+      const last = emissions[emissions.length - 1]!
+      assert.match(last, /^\$IIRMB,A,/)
+      const fields = last.split(',')
+      assert.strictEqual(fields[4], 'DP')
+    })
+
+    it('APB field 10 contains "DP"', async function () {
+      const { emissions } = await runEncoder('APB', s)
+      assert.ok(emissions.length > 0)
+      const fields = emissions[emissions.length - 1]!.split(',')
+      assert.strictEqual(fields[10], 'DP')
+    })
+
+    it('APB-true field 10 contains "DP"', async function () {
+      const { emissions } = await runEncoder('APB-true', s)
+      assert.ok(emissions.length > 0)
+      const fields = emissions[emissions.length - 1]!.split(',')
+      assert.strictEqual(fields[10], 'DP')
+    })
+
+    it('XTE emits a cross-track error sentence', async function () {
+      const { emissions } = await runEncoder('XTE', s)
+      assert.ok(emissions.length > 0)
+      assert.match(emissions[0]!, /^\$IIXTE,A,A,/)
+    })
+  })
+
+  describe('Scenario 2: ' + SCENARIO_WAYPOINT.name, function () {
+    const s = SCENARIO_WAYPOINT
+
+    it('RMB field 4 contains "WP1"', async function () {
+      const { emissions } = await runEncoder('RMB', s)
+      assert.ok(emissions.length > 0, 'RMB must emit')
+      const last = emissions[emissions.length - 1]!
+      assert.match(last, /^\$IIRMB,A,/)
+      const fields = last.split(',')
+      assert.strictEqual(fields[4], 'WP1')
+    })
+
+    it('APB field 10 contains "WP1"', async function () {
+      const { emissions } = await runEncoder('APB', s)
+      assert.ok(emissions.length > 0)
+      const fields = emissions[emissions.length - 1]!.split(',')
+      assert.strictEqual(fields[10], 'WP1')
+    })
+
+    it('APB-true field 10 contains "WP1"', async function () {
+      const { emissions } = await runEncoder('APB-true', s)
+      assert.ok(emissions.length > 0)
+      const fields = emissions[emissions.length - 1]!.split(',')
+      assert.strictEqual(fields[10], 'WP1')
+    })
+
+    it('XTE emits a cross-track error sentence', async function () {
+      const { emissions } = await runEncoder('XTE', s)
+      assert.ok(emissions.length > 0)
+      assert.match(emissions[0]!, /^\$IIXTE,A,A,/)
+    })
+  })
+
+  describe('Scenario 3: ' + SCENARIO_ROUTE.name, function () {
+    const s = SCENARIO_ROUTE
+
+    it('RMB field 4 contains "WP1"', async function () {
+      const { emissions } = await runEncoder('RMB', s)
+      assert.ok(emissions.length > 0, 'RMB must emit')
+      const last = emissions[emissions.length - 1]!
+      assert.match(last, /^\$IIRMB,A,/)
+      const fields = last.split(',')
+      assert.strictEqual(fields[4], 'WP1')
+    })
+
+    it('APB field 10 contains "WP1"', async function () {
+      const { emissions } = await runEncoder('APB', s)
+      assert.ok(emissions.length > 0)
+      const fields = emissions[emissions.length - 1]!.split(',')
+      assert.strictEqual(fields[10], 'WP1')
+    })
+
+    it('APB-true field 10 contains "WP1"', async function () {
+      const { emissions } = await runEncoder('APB-true', s)
+      assert.ok(emissions.length > 0)
+      const fields = emissions[emissions.length - 1]!.split(',')
+      assert.strictEqual(fields[10], 'WP1')
+    })
+
+    it('XTE emits a cross-track error sentence', async function () {
+      const { emissions } = await runEncoder('XTE', s)
+      assert.ok(emissions.length > 0)
+      assert.match(emissions[0]!, /^\$IIXTE,A,A,/)
+    })
+  })
+})

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -23,7 +23,8 @@ const expectations: Expectation[] = [
       'navigation.course.calcValues.bearingTrackTrue',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.nextPoint',
-      'navigation.magneticVariation'
+      'navigation.magneticVariation',
+      'navigation.course.activeRoute'
     ]
   },
   {
@@ -34,7 +35,8 @@ const expectations: Expectation[] = [
       'navigation.course.calcValues.crossTrackError',
       'navigation.course.calcValues.bearingTrackTrue',
       'navigation.course.calcValues.bearingTrue',
-      'navigation.course.nextPoint'
+      'navigation.course.nextPoint',
+      'navigation.course.activeRoute'
     ]
   },
   {
@@ -231,7 +233,8 @@ const expectations: Expectation[] = [
       'navigation.course.calcValues.distance',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.calcValues.velocityMadeGood',
-      'navigation.course.previousPoint'
+      'navigation.course.previousPoint',
+      'navigation.course.activeRoute'
     ]
   },
   {
@@ -318,13 +321,13 @@ const expectations: Expectation[] = [
     keys: ['environment.outside.temperature']
   },
   {
-    name: 'XTE-GC',
-    title: 'XTE - Cross-track error (w.r.t. Great Circle)',
-    keys: ['navigation.courseGreatCircle.crossTrackError']
-  },
-  {
     name: 'XTE',
     title: 'XTE - Cross-track error (w.r.t. Rhumb line)',
+    keys: ['navigation.course.calcValues.crossTrackError']
+  },
+  {
+    name: 'XTE-GC',
+    title: 'XTE - Cross-track error (w.r.t. server-configured calcMethod)',
     keys: ['navigation.course.calcValues.crossTrackError']
   },
   {

--- a/test/sentences.ts
+++ b/test/sentences.ts
@@ -238,7 +238,7 @@ describe('sentence encoders', function () {
     })
   })
 
-  describe('XTE-GC - cross-track error (great circle)', function () {
+  describe('XTE-GC - cross-track error (server-configured calcMethod)', function () {
     const enc = load('XTE-GC')
     it('emits L when xte is positive', function () {
       const s = mustEncode(enc, 100)

--- a/test/snapshots/no-waypoint.json
+++ b/test/snapshots/no-waypoint.json
@@ -1,0 +1,119 @@
+{
+  "scenario": "navigate-to-point (no waypoint, no route)",
+  "calcMethod": "Rhumbline",
+  "capturedAt": "2026-05-08T22:07:43.178Z",
+  "paths": {
+    "navigation.log": 0,
+    "navigation.courseGreatCircle.activeRoute.href": null,
+    "navigation.courseGreatCircle.activeRoute.startTime": "2026-05-08T21:26:55.881Z",
+    "navigation.courseGreatCircle.nextPoint.value.href": null,
+    "navigation.courseGreatCircle.nextPoint.value.type": "Location",
+    "navigation.courseGreatCircle.nextPoint.position": {
+      "latitude": 26.54696714586578,
+      "longitude": -77.06287980079651
+    },
+    "navigation.courseGreatCircle.nextPoint.arrivalCircle": 100,
+    "navigation.courseGreatCircle.previousPoint.position": {
+      "latitude": 26.546606666666666,
+      "longitude": -77.05950333333334
+    },
+    "navigation.courseGreatCircle.previousPoint.value.type": "VesselPosition",
+    "navigation.courseRhumbline.activeRoute.href": null,
+    "navigation.courseRhumbline.activeRoute.startTime": "2026-05-08T21:26:55.881Z",
+    "navigation.courseRhumbline.nextPoint.value.href": null,
+    "navigation.courseRhumbline.nextPoint.value.type": "Location",
+    "navigation.courseRhumbline.nextPoint.position": {
+      "latitude": 26.54696714586578,
+      "longitude": -77.06287980079651
+    },
+    "navigation.courseRhumbline.nextPoint.arrivalCircle": 100,
+    "navigation.courseRhumbline.previousPoint.position": {
+      "latitude": 26.546606666666666,
+      "longitude": -77.05950333333334
+    },
+    "navigation.courseRhumbline.previousPoint.value.type": "VesselPosition",
+    "navigation.course.startTime": "2026-05-08T21:26:55.881Z",
+    "navigation.course.targetArrivalTime": null,
+    "navigation.course.activeRoute": null,
+    "navigation.course.arrivalCircle": 100,
+    "navigation.course.previousPoint": {
+      "position": {
+        "latitude": 26.546606666666666,
+        "longitude": -77.05950333333334
+      },
+      "type": "VesselPosition"
+    },
+    "navigation.course.nextPoint": {
+      "position": {
+        "latitude": 26.54696714586578,
+        "longitude": -77.06287980079651
+      },
+      "type": "Location"
+    },
+    "navigation.headingMagnetic": 1.2915436467707015,
+    "environment.sun": "day",
+    "environment.mode": "day",
+    "navigation.magneticVariation": -0.16089135395421264,
+    "navigation.magneticVariation.source": "WMM 2025",
+    "navigation.courseOverGroundTrue": 0.7930776122873063,
+    "navigation.courseOverGroundMagnetic": 0.953968966241519,
+    "navigation.courseGreatCircle.nextPoint.steerError": 2.2526603856373573,
+    "navigation.courseGreatCircle.nextPoint.leftSteerError": 2.2526603856373573,
+    "navigation.courseGreatCircle.nextPoint.rightSteerError": 0,
+    "navigation.headingTrue": 0.9404253969801876,
+    "navigation.leewayAngle": -0.14734778469288126,
+    "environment.wind.directionTrue": 1.3665894218146333,
+    "environment.wind.angleTrueGround": 0.4276056668362458,
+    "environment.wind.speedOverGround": 3.1381119060994607,
+    "environment.current.drift": 0,
+    "environment.current.setTrue": null,
+    "environment.current.setMagnetic": null,
+    "environment.current.driftImpact": 0,
+    "steering.rudderAngle": 0.0174532925239284,
+    "steering.autopilot.state": "standby",
+    "environment.wind.speedApparent": 3.1381119060994607,
+    "environment.wind.angleTrueWater": 0.4276056668362458,
+    "environment.wind.speedTrue": 3.1381119060994607,
+    "environment.depth.belowTransducer": 1.00584,
+    "environment.depth.belowKeel": 1.00584,
+    "environment.depth.belowSurface": 2.25584,
+    "navigation.speedThroughWater": 0,
+    "navigation.averageSpeedThroughWater": 0,
+    "navigation.gnss.methodQuality": "GNSS Fix",
+    "navigation.gnss.satellites": 8,
+    "navigation.gnss.antennaAltitude": 8.1,
+    "navigation.gnss.horizontalDilution": 1,
+    "navigation.gnss.geoidalSeparation": -33,
+    "navigation.gnss.differentialAge": 0,
+    "navigation.gnss.differentialReference": 0,
+    "environment.water.temperature": 309.15,
+    "navigation.position": {
+      "latitude": 26.546631666666666,
+      "longitude": -77.05952166666667
+    },
+    "navigation.speedOverGround": 0,
+    "navigation.magneticVariationAgeOfService": 1778278056,
+    "navigation.datetime": "2026-05-08T22:07:36.000Z",
+    "environment.wind.angleApparent": 0.42760566683624573,
+    "navigation.attitude": {
+      "roll": 0.00018849556440000002,
+      "pitch": 0.019057250626700002,
+      "yaw": 1.1013167509344002
+    },
+    "navigation.course.calcValues.calcMethod": "Rhumbline",
+    "navigation.course.calcValues.bearingTrackTrue": 4.831171944671482,
+    "navigation.course.calcValues.bearingTrackMagnetic": 4.670280590717269,
+    "navigation.course.calcValues.crossTrackError": 2.5441476328008386,
+    "navigation.course.calcValues.previousPoint.distance": 3.3246639121881345,
+    "navigation.course.calcValues.distance": 336.1154538639113,
+    "navigation.course.calcValues.bearingTrue": 4.823602533829535,
+    "navigation.course.calcValues.bearingMagnetic": 4.6627111798753225,
+    "navigation.course.calcValues.velocityMadeGood": 0,
+    "navigation.course.calcValues.timeToGo": null,
+    "navigation.course.calcValues.estimatedTimeOfArrival": null,
+    "navigation.course.calcValues.route.timeToGo": null,
+    "navigation.course.calcValues.route.estimatedTimeOfArrival": null,
+    "navigation.course.calcValues.route.distance": null,
+    "navigation.course.calcValues.targetSpeed": null
+  }
+}

--- a/test/snapshots/route.json
+++ b/test/snapshots/route.json
@@ -1,0 +1,125 @@
+{
+  "scenario": "navigate-with-active-route",
+  "calcMethod": "Rhumbline",
+  "capturedAt": "2026-05-08T22:36:05.031Z",
+  "paths": {
+    "navigation.log": 0,
+    "environment.sun": "day",
+    "environment.mode": "day",
+    "navigation.headingMagnetic": 1.4137166944382002,
+    "navigation.courseGreatCircle.activeRoute.href": "/resources/routes/c1551d44-65dc-409d-b09a-7482202cc2a1",
+    "navigation.courseGreatCircle.activeRoute.startTime": "2026-05-08T22:35:32.264Z",
+    "navigation.courseGreatCircle.nextPoint.value.href": null,
+    "navigation.courseGreatCircle.nextPoint.value.type": "RoutePoint",
+    "navigation.courseGreatCircle.nextPoint.position": {
+      "latitude": 26.54661003894277,
+      "longitude": -77.06357717514038
+    },
+    "navigation.courseGreatCircle.nextPoint.arrivalCircle": 100,
+    "navigation.courseGreatCircle.previousPoint.position": {
+      "latitude": 26.546718333333335,
+      "longitude": -77.05952833333333
+    },
+    "navigation.courseGreatCircle.previousPoint.value.type": "VesselPosition",
+    "navigation.courseRhumbline.activeRoute.href": "/resources/routes/c1551d44-65dc-409d-b09a-7482202cc2a1",
+    "navigation.courseRhumbline.activeRoute.startTime": "2026-05-08T22:35:32.264Z",
+    "navigation.courseRhumbline.nextPoint.value.href": null,
+    "navigation.courseRhumbline.nextPoint.value.type": "RoutePoint",
+    "navigation.courseRhumbline.nextPoint.position": {
+      "latitude": 26.54661003894277,
+      "longitude": -77.06357717514038
+    },
+    "navigation.courseRhumbline.nextPoint.arrivalCircle": 100,
+    "navigation.courseRhumbline.previousPoint.position": {
+      "latitude": 26.546718333333335,
+      "longitude": -77.05952833333333
+    },
+    "navigation.courseRhumbline.previousPoint.value.type": "VesselPosition",
+    "navigation.course.startTime": "2026-05-08T22:35:32.264Z",
+    "navigation.course.targetArrivalTime": null,
+    "navigation.course.activeRoute": {
+      "href": "/resources/routes/c1551d44-65dc-409d-b09a-7482202cc2a1",
+      "name": "Route 20260508 (2)",
+      "reverse": false,
+      "pointIndex": 0,
+      "pointTotal": 3
+    },
+    "navigation.course.arrivalCircle": 100,
+    "navigation.course.previousPoint": {
+      "position": {
+        "latitude": 26.546718333333335,
+        "longitude": -77.05952833333333
+      },
+      "type": "VesselPosition"
+    },
+    "navigation.course.nextPoint": {
+      "type": "RoutePoint",
+      "position": {
+        "latitude": 26.54661003894277,
+        "longitude": -77.06357717514038
+      }
+    },
+    "navigation.headingTrue": 1.3245374693241874,
+    "navigation.leewayAngle": -0.5235987755982988,
+    "environment.wind.directionTrue": 0.9231117412738342,
+    "environment.wind.angleTrueGround": -0.40142572805035315,
+    "environment.wind.speedOverGround": 2.5207784163749767,
+    "steering.rudderAngle": 0.0174532925239284,
+    "navigation.magneticVariation": -0.16089135395421264,
+    "navigation.magneticVariation.source": "WMM 2025",
+    "navigation.courseOverGroundTrue": 0.7930776122873063,
+    "navigation.courseOverGroundMagnetic": 0.953968966241519,
+    "environment.current.drift": 0,
+    "environment.current.setTrue": null,
+    "environment.current.setMagnetic": null,
+    "environment.current.driftImpact": 0,
+    "environment.water.temperature": 309.15,
+    "navigation.gnss.methodQuality": "GNSS Fix",
+    "navigation.gnss.satellites": 8,
+    "navigation.gnss.antennaAltitude": 7.2,
+    "navigation.gnss.horizontalDilution": 0.9,
+    "navigation.gnss.geoidalSeparation": -33,
+    "navigation.gnss.differentialAge": 0,
+    "navigation.gnss.differentialReference": 0,
+    "navigation.courseGreatCircle.nextPoint.steerError": 2.394224035462287,
+    "navigation.courseGreatCircle.nextPoint.leftSteerError": 2.394224035462287,
+    "navigation.courseGreatCircle.nextPoint.rightSteerError": 0,
+    "environment.wind.angleApparent": -0.40142572805035315,
+    "environment.wind.angleTrueWater": -0.40142572805035315,
+    "environment.wind.speedTrue": 2.829445161237219,
+    "environment.wind.speedApparent": 2.829445161237219,
+    "navigation.position": {
+      "latitude": 26.54672,
+      "longitude": -77.05952833333333
+    },
+    "navigation.speedOverGround": 0,
+    "navigation.magneticVariationAgeOfService": 1778279755,
+    "navigation.datetime": "2026-05-08T22:35:55.000Z",
+    "steering.autopilot.state": "standby",
+    "environment.depth.belowTransducer": 0.94488,
+    "environment.depth.belowKeel": 0.94488,
+    "environment.depth.belowSurface": 2.19488,
+    "navigation.course.calcValues.calcMethod": "Rhumbline",
+    "navigation.course.calcValues.bearingTrackTrue": 4.682498620978,
+    "navigation.course.calcValues.bearingTrackMagnetic": 4.5216072670237875,
+    "navigation.course.calcValues.crossTrackError": 0.18524218386861044,
+    "navigation.course.calcValues.previousPoint.distance": 0.1853248780021577,
+    "navigation.course.calcValues.distance": 402.9308132880701,
+    "navigation.course.calcValues.bearingTrue": 4.682038884004606,
+    "navigation.course.calcValues.bearingMagnetic": 4.521147530050393,
+    "navigation.course.calcValues.velocityMadeGood": 0,
+    "navigation.course.calcValues.timeToGo": null,
+    "navigation.course.calcValues.estimatedTimeOfArrival": null,
+    "navigation.course.calcValues.route.timeToGo": null,
+    "navigation.course.calcValues.route.estimatedTimeOfArrival": null,
+    "navigation.course.calcValues.route.distance": null,
+    "navigation.course.calcValues.targetSpeed": null,
+    "navigation.speedThroughWater": 0,
+    "navigation.averageSpeedThroughWater": 0,
+    "navigation.attitude": {
+      "roll": -0.0018814649854000003,
+      "pitch": 0.015830136751000003,
+      "yaw": 1.4967996436679
+    }
+  }
+}

--- a/test/snapshots/waypoint.json
+++ b/test/snapshots/waypoint.json
@@ -1,0 +1,120 @@
+{
+  "scenario": "navigate-to-waypoint (named waypoint, no route)",
+  "calcMethod": "Rhumbline",
+  "capturedAt": "2026-05-08T22:19:19.065Z",
+  "paths": {
+    "navigation.log": 0,
+    "navigation.magneticVariation": -0.16089135395421264,
+    "navigation.courseGreatCircle.activeRoute.href": null,
+    "navigation.courseGreatCircle.activeRoute.startTime": "2026-05-08T22:18:32.147Z",
+    "navigation.courseGreatCircle.nextPoint.value.href": "/resources/waypoints/c9dc41b2-1bce-4e7d-80f2-882aca7a3eae",
+    "navigation.courseGreatCircle.nextPoint.value.type": "Waypoint",
+    "navigation.courseGreatCircle.nextPoint.position": {
+      "latitude": 26.547003799661532,
+      "longitude": -77.06213951110841
+    },
+    "navigation.courseGreatCircle.nextPoint.arrivalCircle": 100,
+    "navigation.courseGreatCircle.previousPoint.position": {
+      "latitude": 26.546733333333332,
+      "longitude": -77.05952333333333
+    },
+    "navigation.courseGreatCircle.previousPoint.value.type": "VesselPosition",
+    "navigation.courseRhumbline.activeRoute.href": null,
+    "navigation.courseRhumbline.activeRoute.startTime": "2026-05-08T22:18:32.147Z",
+    "navigation.courseRhumbline.nextPoint.value.href": "/resources/waypoints/c9dc41b2-1bce-4e7d-80f2-882aca7a3eae",
+    "navigation.courseRhumbline.nextPoint.value.type": "Waypoint",
+    "navigation.courseRhumbline.nextPoint.position": {
+      "latitude": 26.547003799661532,
+      "longitude": -77.06213951110841
+    },
+    "navigation.courseRhumbline.nextPoint.arrivalCircle": 100,
+    "navigation.courseRhumbline.previousPoint.position": {
+      "latitude": 26.546733333333332,
+      "longitude": -77.05952333333333
+    },
+    "navigation.courseRhumbline.previousPoint.value.type": "VesselPosition",
+    "navigation.course.startTime": "2026-05-08T22:18:32.147Z",
+    "navigation.course.targetArrivalTime": null,
+    "navigation.course.activeRoute": null,
+    "navigation.course.arrivalCircle": 100,
+    "navigation.course.previousPoint": {
+      "position": {
+        "latitude": 26.546733333333332,
+        "longitude": -77.05952333333333
+      },
+      "type": "VesselPosition"
+    },
+    "navigation.course.nextPoint": {
+      "position": {
+        "latitude": 26.547003799661532,
+        "longitude": -77.06213951110841
+      },
+      "href": "/resources/waypoints/c9dc41b2-1bce-4e7d-80f2-882aca7a3eae",
+      "type": "Waypoint"
+    },
+    "navigation.headingMagnetic": 1.274090354246773,
+    "environment.sun": "day",
+    "environment.mode": "day",
+    "navigation.magneticVariation.source": "WMM 2025",
+    "navigation.courseOverGroundTrue": 0.7930776122873063,
+    "navigation.courseOverGroundMagnetic": 0.953968966241519,
+    "navigation.courseGreatCircle.nextPoint.steerError": 2.2480419778098266,
+    "navigation.courseGreatCircle.nextPoint.leftSteerError": 2.2480419778098266,
+    "navigation.courseGreatCircle.nextPoint.rightSteerError": 0,
+    "navigation.headingTrue": 1.0766902367483873,
+    "navigation.leewayAngle": -0.28361262446108093,
+    "environment.wind.directionTrue": 1.4408496945372837,
+    "environment.wind.angleTrueGround": 0.3665191430024964,
+    "environment.wind.speedOverGround": 3.704000938346905,
+    "environment.current.drift": 0,
+    "environment.current.setTrue": null,
+    "environment.current.setMagnetic": null,
+    "environment.current.driftImpact": 0,
+    "steering.rudderAngle": 0.0174532925239284,
+    "environment.water.temperature": 309.15,
+    "environment.wind.angleTrueWater": 0.31415926543071115,
+    "environment.wind.speedTrue": 3.704000938346905,
+    "navigation.gnss.methodQuality": "GNSS Fix",
+    "navigation.gnss.satellites": 8,
+    "navigation.gnss.antennaAltitude": 7.5,
+    "navigation.gnss.horizontalDilution": 1,
+    "navigation.gnss.geoidalSeparation": -33,
+    "navigation.gnss.differentialAge": 0,
+    "navigation.gnss.differentialReference": 0,
+    "navigation.position": {
+      "latitude": 26.546731666666666,
+      "longitude": -77.059525
+    },
+    "navigation.speedOverGround": 0,
+    "navigation.magneticVariationAgeOfService": 1778278749,
+    "navigation.datetime": "2026-05-08T22:19:09.000Z",
+    "environment.depth.belowTransducer": 1.15824,
+    "environment.depth.belowKeel": 1.15824,
+    "environment.depth.belowSurface": 2.40824,
+    "steering.autopilot.state": "standby",
+    "navigation.speedThroughWater": 0,
+    "navigation.averageSpeedThroughWater": 0,
+    "environment.wind.angleApparent": 0.3665191430024964,
+    "navigation.attitude": {
+      "roll": -0.0037384953606000005,
+      "pitch": 0.017287486716500003,
+      "yaw": 1.2375815907026
+    },
+    "navigation.course.calcValues.calcMethod": "Rhumbline",
+    "navigation.course.calcValues.bearingTrackTrue": 4.827445107318298,
+    "navigation.course.calcValues.bearingTrackMagnetic": 4.666553753364085,
+    "navigation.course.calcValues.crossTrackError": -0.20313368473614887,
+    "navigation.course.calcValues.previousPoint.distance": 0.24865707330175507,
+    "navigation.course.calcValues.distance": 261.8239416044419,
+    "navigation.course.calcValues.bearingTrue": 4.828220941657066,
+    "navigation.course.calcValues.bearingMagnetic": 4.667329587702853,
+    "navigation.course.calcValues.velocityMadeGood": 0,
+    "navigation.course.calcValues.timeToGo": null,
+    "navigation.course.calcValues.estimatedTimeOfArrival": null,
+    "navigation.course.calcValues.route.timeToGo": null,
+    "navigation.course.calcValues.route.estimatedTimeOfArrival": null,
+    "navigation.course.calcValues.route.distance": null,
+    "navigation.course.calcValues.targetSpeed": null,
+    "environment.wind.speedApparent": 3.652556480869864
+  }
+}

--- a/test/waypointNameGenerator.ts
+++ b/test/waypointNameGenerator.ts
@@ -1,0 +1,113 @@
+import * as assert from 'assert'
+
+import { generateWaypointName } from '../src/waypointNameGenerator'
+
+describe('generateWaypointName', function () {
+  describe('priority: point.name wins over fallback', function () {
+    it('uses nextPoint.name when present', function () {
+      assert.strictEqual(
+        generateWaypointName(
+          { name: 'NASSAU', type: 'Waypoint' },
+          { name: 'Bahamas Cruise', pointIndex: 2 }
+        ),
+        'NASSAU'
+      )
+    })
+  })
+
+  describe('RoutePoint fallback uses activeRoute.pointIndex', function () {
+    it('synthesizes "WP1" for pointIndex 0', function () {
+      assert.strictEqual(
+        generateWaypointName(
+          { type: 'RoutePoint' },
+          { name: 'Bahamas', pointIndex: 0 }
+        ),
+        'WP1'
+      )
+    })
+    it('synthesizes "WP3" for pointIndex 2', function () {
+      assert.strictEqual(
+        generateWaypointName({ type: 'RoutePoint' }, { pointIndex: 2 }),
+        'WP3'
+      )
+    })
+    it('synthesizes "WP6" for pointIndex 5 even without route name', function () {
+      assert.strictEqual(
+        generateWaypointName({ type: 'RoutePoint' }, { pointIndex: 5 }),
+        'WP6'
+      )
+    })
+    it('falls back to "WP1" for RoutePoint when pointIndex is missing', function () {
+      assert.strictEqual(
+        generateWaypointName({ type: 'RoutePoint' }, null),
+        'WP1'
+      )
+    })
+  })
+
+  describe('type-specific defaults (mirrors signalk-server #2608)', function () {
+    it('returns "DP" for direct-to-Location', function () {
+      assert.strictEqual(generateWaypointName({ type: 'Location' }, null), 'DP')
+    })
+    it('returns "VP" for previous VesselPosition', function () {
+      assert.strictEqual(
+        generateWaypointName({ type: 'VesselPosition' }, null),
+        'VP'
+      )
+    })
+    it('returns "WP1" for direct-to-Waypoint with no name', function () {
+      assert.strictEqual(
+        generateWaypointName(
+          { type: 'Waypoint', href: '/resources/waypoints/abc-123' },
+          null
+        ),
+        'WP1'
+      )
+    })
+    it('returns "WP1" for unknown / missing type', function () {
+      assert.strictEqual(generateWaypointName({}, null), 'WP1')
+    })
+    it('returns "WP1" for null nextPoint and null activeRoute', function () {
+      assert.strictEqual(generateWaypointName(null, null), 'WP1')
+    })
+  })
+
+  describe('NMEA framing-character defenses', function () {
+    it('strips comma, asterisk, dollar, CR, LF from name', function () {
+      assert.strictEqual(
+        generateWaypointName({ name: 'A,B*C$D\rE\nF' }, null),
+        'ABCDEF'
+      )
+    })
+    it('truncates names longer than 20 characters', function () {
+      assert.strictEqual(
+        generateWaypointName(
+          { name: 'A_VERY_LONG_WAYPOINT_NAME_THAT_OVERFLOWS' },
+          null
+        ),
+        'A_VERY_LONG_WAYPOINT'
+      )
+    })
+  })
+
+  describe('robustness against partial/undefined inputs', function () {
+    it('treats undefined nextPoint as empty object', function () {
+      assert.strictEqual(
+        generateWaypointName(undefined, { pointIndex: 0 }),
+        'WP1'
+      )
+    })
+    it('treats undefined activeRoute as empty object', function () {
+      assert.strictEqual(generateWaypointName({ name: 'X' }, undefined), 'X')
+    })
+    it('ignores non-numeric pointIndex (falls back to type default)', function () {
+      assert.strictEqual(
+        generateWaypointName(
+          { type: 'RoutePoint' },
+          { pointIndex: '1' as unknown as number }
+        ),
+        'WP1'
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- The five routing/waypoint sentences (RMB, APB, APB-true, BWC, XTE) now produce a usable identifier in every navigation mode instead of leaving fields empty. A new `generateWaypointName(point, activeRoute)` helper resolves the name with a clear priority chain: `point.name` → type-aware fallback → last-ditch `WP1`.
- The fallback **mirrors the defaults that SignalK/signalk-server#2608 will publish** in the deltastream, so the NMEA output is identical before and after that PR ships:
  - `RoutePoint` → `WP<pointIndex+1>` (e.g. `WP1`, `WP2`)
  - `Location`  → `DP` (Destination Position)
  - `VesselPosition` → `VP` (used for RMB field 5 / FROM)
  - `Waypoint` / unknown → `WP1`
- The fallback is **encapsulated in a single `synthesizeFallbackName()` function** with a prominent comment instructing future maintainers to remove it once #2608 is released and `point.name` is reliably populated.
- BWC's existing local `deriveWaypointId` is replaced with the shared helper; BWC is the "Bearing and distance to Waypoint" sentence used for both active-route AND "goto" navigation, so the goto cases now emit the same type-aware identifier.
- `XTE-GC`'s subscription is corrected from the dead path `navigation.courseGreatCircle.crossTrackError` (which signalk-server 2.x has never published) to `navigation.course.calcValues.crossTrackError`. Both `XTE` and `XTE-GC` are functionally equivalent now and are kept so existing user configs that enable `XTE-GC: true` continue to emit. Regular `XTE` and the `$IIXTE` sentence are unchanged.
- Adds snapshot-driven regression tests covering the three navigation modes, captured from a live signalk-server (2.26.0) and inlined for self-containment.
- Adds `scripts/capture-snapshot.ts` (capture deltastreams) and `scripts/probe-snapshot.ts` (run every encoder against a captured snapshot, report per-encoder emission).

## Forward compatibility with signalk-server #2608

Once that PR ships, signalk-server populates `nextPoint.name` and `previousPoint.name` in the delta stream with these defaults: `WP<n+1>` for route points, `WP1` for waypoint resources, `DP` for direct-to-position, `VP` for previousPoint at the start of any goto. This plugin's helper:

1. **Forwards the name as-is** when present (`point.name`).
2. **Synthesizes the same defaults locally** when the name is absent (pre-2608).

Net effect: identical NMEA output before and after the upstream PR lands. The `synthesizeFallbackName()` function can be deleted once 2608 is widely deployed.

## Behavior across the three live scenarios

All five routing sentences (RMB, APB, APB-true, BWC, XTE) now produce type-aware identifiers consistently:

| Scenario | Field 4/10/12 (after) | RMB Field 5 (after) |
|---|---|---|
| navigate-to-point (Location) | `DP` | `VP` |
| navigate-to-waypoint (Waypoint, no name in delta) | `WP1` | `VP` |
| active multi-point route (RoutePoint, pointIndex 0) | `WP1` | `VP` |

Live verification:

```
no-waypoint:
  RMB -> $IIRMB,A,0.001,L,DP,VP,2632.8180,N,07703.7728,W,...
  APB -> $IIAPB,A,A,0.001,L,N,V,V,286,M,DP,286,M,286,M*1B
  BWC -> $IIBWC,220736.00,2632.8180,N,07703.7728,W,...,N,DP*0C
  XTE -> $IIXTE,A,A,0.001,L,N*48

waypoint ("to delete"):
  RMB -> $IIRMB,A,0.000,R,WP1,VP,2632.8202,N,07703.7284,W,...
  APB -> $IIAPB,A,A,0.000,R,N,V,V,286,M,WP1,286,M,286,M*26
  BWC -> $IIBWC,221909.00,2632.8202,N,07703.7284,W,...,N,WP1*2F
  XTE -> $IIXTE,A,A,0.000,R,N*57

route (3-point, at point 1):
  RMB -> $IIRMB,A,0.000,L,WP1,VP,2632.7966,N,07703.8146,W,...
  APB -> $IIAPB,A,A,0.000,L,N,V,V,278,M,WP1,277,M,277,M*39
  BWC -> $IIBWC,223555.00,2632.7966,N,07703.8146,W,...,N,WP1*2A
  XTE -> $IIXTE,A,A,0.000,L,N*49
```

## Test plan

- [x] Unit tests for `generateWaypointName` (priority chain, type-specific defaults DP/VP/WP1, NMEA framing-character defenses, partial inputs)
- [x] Snapshot-driven integration tests for all three live scenarios with type-aware expectations
- [x] Existing RMB / APB / APB-true / BWC / XTE-GC tests updated to mirror the new naming convention
- [x] `npm run typecheck` clean
- [x] `npm test` -- 367 passing, 0 failing
- [x] `npm run prettier:check` clean
- [x] Live verification against a running signalk-server (2.26.0)

## Notes for reviewers

- `synthesizeFallbackName()` is intentionally a separate, well-marked function so it can be removed in a one-line change once SignalK/signalk-server#2608 lands.
- BWC's local `deriveWaypointId`, `NextPoint`/`ActiveRoute` interfaces, and NMEA framing-character constants are now consolidated into `src/waypointNameGenerator.ts` -- single source of truth across all routing sentences.
- `scripts/probe-snapshot.ts` and `scripts/capture-snapshot.ts` live outside `test/` so mocha does not pick them up. Full deltastream snapshots remain in `test/snapshots/*.json` for diagnostic re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)