### PR TITLE
fix(routing): use server-provided waypoint names, drop client-side synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,15 @@ Each sentence is independently toggleable and has its own throttle
 
 - **APB** — autopilot info, magnetic bearings (`--true` variant also
   available)
+- **BWC** — bearing and distance to waypoint
 - **RMB** — recommended minimum navigation info to waypoint
 - **XTE** — cross-track error (`-GC` great-circle variant also available)
+
+The waypoint identifier in these sentences is taken from the `name`
+the Signal K server publishes on the active destination (the server
+supplies its own `WP<n>` / `DP` / `VP` defaults). Servers that support
+waypoint naming fill it; older servers leave the identifier fields
+empty.
 
 ### Position, heading, speed
 

--- a/src/sentences/APB-true.ts
+++ b/src/sentences/APB-true.ts
@@ -4,12 +4,12 @@ $--APB,A,A,x.x,a,N,A,A,x.x,a,c--c,x.x,a,x.x,a*hh
 Same field layout as APB but all three bearing pairs are reported True. For
 autopilots that require Magnetic bearings use APB.
 
-Waypoint ID (field 10) follows the BWC pattern: prefer `nextPoint.name`, then
-synthesize "WP <pointIndex+1>" from `activeRoute.pointIndex`, else empty.
+Field 10 (Destination Waypoint ID) is nextPoint.name, forwarded by
+generateWaypointName; it is emitted empty when the server sends no name.
 */
 import * as nmea from '../nmea'
 import { generateWaypointName } from '../waypointNameGenerator'
-import type { ActiveRoute, NextPoint } from '../waypointNameGenerator'
+import type { NextPoint } from '../waypointNameGenerator'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
 
 export default function (_app: SignalKApp): SentenceEncoder {
@@ -20,18 +20,16 @@ export default function (_app: SignalKApp): SentenceEncoder {
       'navigation.course.calcValues.crossTrackError',
       'navigation.course.calcValues.bearingTrackTrue',
       'navigation.course.calcValues.bearingTrue',
-      'navigation.course.nextPoint',
-      'navigation.course.activeRoute'
+      'navigation.course.nextPoint'
     ],
-    defaults: [undefined, undefined, undefined, {}, {}],
+    defaults: [undefined, undefined, undefined, {}],
     f: function (
       xte: number,
       originToDest: number,
       bearingTrue: number,
-      nextPoint: NextPoint | null | undefined,
-      activeRoute: ActiveRoute | null | undefined
+      nextPoint: NextPoint | null | undefined
     ): string {
-      const waypointId = generateWaypointName(nextPoint, activeRoute)
+      const waypointId = generateWaypointName(nextPoint)
       return nmea.toSentence([
         '$IIAPB',
         'A',

--- a/src/sentences/APB.ts
+++ b/src/sentences/APB.ts
@@ -20,12 +20,12 @@ All three bearing pairs are reported Magnetic, computed from the True bearings
 and `navigation.magneticVariation`. For autopilots that require True bearings
 use APB-true.
 
-Waypoint ID (field 10) follows the BWC pattern: prefer `nextPoint.name`, then
-synthesize "WP <pointIndex+1>" from `activeRoute.pointIndex`, else empty.
+Field 10 (Destination Waypoint ID) is nextPoint.name, forwarded by
+generateWaypointName; it is emitted empty when the server sends no name.
 */
 import * as nmea from '../nmea'
 import { generateWaypointName } from '../waypointNameGenerator'
-import type { ActiveRoute, NextPoint } from '../waypointNameGenerator'
+import type { NextPoint } from '../waypointNameGenerator'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
 
 export default function (_app: SignalKApp): SentenceEncoder {
@@ -37,19 +37,17 @@ export default function (_app: SignalKApp): SentenceEncoder {
       'navigation.course.calcValues.bearingTrackTrue',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.nextPoint',
-      'navigation.magneticVariation',
-      'navigation.course.activeRoute'
+      'navigation.magneticVariation'
     ],
-    defaults: [undefined, undefined, undefined, {}, undefined, {}],
+    defaults: [undefined, undefined, undefined, {}, undefined],
     f: function (
       xte: number,
       originToDest: number,
       bearingTrue: number,
       nextPoint: NextPoint | null | undefined,
-      magneticVariation: number,
-      activeRoute: ActiveRoute | null | undefined
+      magneticVariation: number
     ): string {
-      const waypointId = generateWaypointName(nextPoint, activeRoute)
+      const waypointId = generateWaypointName(nextPoint)
       const bearingOriginToDestMag = nmea.radsToPositiveDeg(
         nmea.fixAngle(originToDest - magneticVariation)
       )

--- a/src/sentences/BWC.ts
+++ b/src/sentences/BWC.ts
@@ -24,25 +24,21 @@ Signal K source paths verified by subscribing to the live deltastream of a
 running signalk-server with an active route:
 
   - navigation.datetime                            -> ISO datetime
-  - navigation.course.nextPoint                    -> {type, position, [name]}
-  - navigation.course.activeRoute                  -> {href, name, pointIndex, pointTotal}
+  - navigation.course.nextPoint                    -> {type, position, name?}
   - navigation.course.calcValues.bearingTrue       -> bearing to waypoint (rad)
   - navigation.course.calcValues.bearingMagnetic   -> bearing to waypoint, magnetic (rad, optional)
   - navigation.course.calcValues.distance          -> distance to waypoint (m)
 
-`navigation.course.nextPoint` is the canonical waypoint path: it is published
-as a composite delta containing both `type` (RoutePoint / Location /
-VesselPosition) and `position` regardless of the active calculation method.
-The parallel `navigation.courseGreatCircle.nextPoint` is silent on the
-deltastream (only its leaf children emit) and is NOT what to subscribe to.
+`navigation.course.nextPoint` is the canonical waypoint path: a single
+composite delta carrying `type` and `position` (plus `name`, on servers that
+publish it) for every calculation method. The parallel
+`navigation.courseGreatCircle.nextPoint` only emits its leaf children on the
+delta stream, never the composite, so do NOT subscribe to it.
 
-Waypoint name (field 12) is resolved by `generateWaypointName`, shared with
-RMB/APB/APB-true:
-  1. nextPoint.name when SignalK/signalk-server#2608 lands
-  2. "WP <pointIndex+1>" when a route is active (e.g. "WP 1", "WP 2")
-  3. "WP 1" as a single-point default. BWC is used for both active-route
-     and "goto" navigation, so a sensible identifier is preferred over an
-     empty field that some chartplotters reject.
+Field 12 (Waypoint ID) is whatever name the server set on nextPoint, forwarded
+by generateWaypointName (shared with RMB/APB/APB-true). Along an active route
+that is typically "WP1", "WP2", ...; for a go-to position it is "DP". If the
+server sends no name the field is emitted empty.
 
 Bearing values reflect the calcMethod set in signalk-server (GreatCircle or
 Rhumbline). For typical sailing distances the difference is negligible; if
@@ -51,7 +47,7 @@ GreatCircle.
 */
 import * as nmea from '../nmea'
 import { generateWaypointName } from '../waypointNameGenerator'
-import type { ActiveRoute, NextPoint } from '../waypointNameGenerator'
+import type { NextPoint } from '../waypointNameGenerator'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
 
 function inLatRange(v: unknown): v is number {
@@ -72,20 +68,17 @@ export default function (_app: SignalKApp): SentenceEncoder {
     keys: [
       'navigation.datetime',
       'navigation.course.nextPoint',
-      'navigation.course.activeRoute',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.calcValues.bearingMagnetic',
       'navigation.course.calcValues.distance'
     ],
-    // activeRoute defaults to {} so a Location-type destination (no route)
-    // still emits; bearingMagnetic seeds with null so older servers that
-    // don't publish it still let the combined stream fire (encoder emits
-    // empty fields 8/9 when magnetic is missing).
-    defaults: ['', undefined, {}, undefined, null, undefined],
+    // bearingMagnetic seeds with null so servers that don't publish it still
+    // let the combined stream fire (the encoder emits empty fields 8/9 when
+    // magnetic is missing).
+    defaults: ['', undefined, undefined, null, undefined],
     f: function (
       datetime8601: string,
       nextPoint: NextPoint | null | undefined,
-      activeRoute: ActiveRoute | null | undefined,
       bearingTrue: number | undefined,
       bearingMagnetic: number | null | undefined,
       distance: number | undefined
@@ -122,7 +115,7 @@ export default function (_app: SignalKApp): SentenceEncoder {
         ? nmea.radsToPositiveDeg(bearingMagnetic as number)
         : undefined
 
-      const waypointId = generateWaypointName(nextPoint, activeRoute)
+      const waypointId = generateWaypointName(nextPoint)
 
       return nmea.toSentence([
         '$IIBWC',

--- a/src/sentences/RMB.ts
+++ b/src/sentences/RMB.ts
@@ -24,15 +24,14 @@ Field Number:
 14. FAA mode indicator (NMEA 2.3 and later)
 15. Checksum
 
-Field 4 (TO Waypoint ID) is derived via generateWaypointName: prefer nextPoint.name,
-synthesize "WP <pointIndex+1>" from activeRoute.pointIndex, else empty. Field 5
-(FROM) uses previousPoint.name when available -- in practice signalk-server
-emits previousPoint as a VesselPosition without a name, so this falls back to
-empty in direct-to-point and route-by-name cases.
+Field 4 (TO Waypoint ID) comes from nextPoint.name and field 5 (FROM) from
+previousPoint.name, both forwarded by generateWaypointName. A server that names
+its course points fills these (e.g. "WP2"/"WP1" along a route, or "DP" for a
+go-to position with "VP" as the origin); otherwise they are emitted empty.
 */
 import * as nmea from '../nmea'
 import { generateWaypointName } from '../waypointNameGenerator'
-import type { ActiveRoute, NextPoint } from '../waypointNameGenerator'
+import type { NextPoint } from '../waypointNameGenerator'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
 
 type PreviousPoint = NextPoint
@@ -47,26 +46,24 @@ export default function (_app: SignalKApp): SentenceEncoder {
       'navigation.course.calcValues.distance',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.calcValues.velocityMadeGood',
-      'navigation.course.previousPoint',
-      'navigation.course.activeRoute'
+      'navigation.course.previousPoint'
     ],
-    defaults: [undefined, {}, undefined, undefined, undefined, {}, {}],
+    defaults: [undefined, {}, undefined, undefined, undefined, {}],
     f: function (
       crossTrackError: number,
       wp: NextPoint,
       wpDistance: number,
       bearingTrue: number,
       vmg: number,
-      prevWp: PreviousPoint | null | undefined,
-      activeRoute: ActiveRoute | null | undefined
+      prevWp: PreviousPoint | null | undefined
     ): string | undefined {
       const wpLat = wp?.position?.latitude
       const wpLon = wp?.position?.longitude
       if (typeof wpLat !== 'number' || typeof wpLon !== 'number') {
         return undefined
       }
-      const destinationId = generateWaypointName(wp, activeRoute)
-      const originId = generateWaypointName(prevWp, activeRoute)
+      const destinationId = generateWaypointName(wp)
+      const originId = generateWaypointName(prevWp)
       return nmea.toSentence([
         '$IIRMB',
         'A',

--- a/src/waypointNameGenerator.ts
+++ b/src/waypointNameGenerator.ts
@@ -1,18 +1,19 @@
 /**
- * Generates a NMEA0183 waypoint identifier from Signal K's `nextPoint` /
- * `previousPoint` and `activeRoute` deltas. Used by RMB (fields 4 and 5),
- * APB (field 10), APB-true (field 10), and BWC (field 12).
+ * Resolves the NMEA0183 waypoint identifier (the "c--c" Waypoint ID field)
+ * from a Signal K course point. Shared by RMB (fields 4/5), APB and APB-true
+ * (field 10), and BWC (field 12).
  *
- * Resolution order:
- *   1. `point.name`              -- once signalk-server populates this
- *      in the delta stream (see SignalK/signalk-server#2608).
- *   2. `synthesizeFallbackName()` -- pre-2608 fallback that mirrors the
- *      defaults the upstream PR applies, so behavior is consistent both
- *      before and after that PR ships. REMOVE the fallback once #2608
- *      is released and we can rely on `point.name` always being set.
+ * The Signal K server owns waypoint naming. When a destination is set it
+ * publishes `nextPoint.name` / `previousPoint.name`, using the route point or
+ * waypoint resource name where the operator gave one and otherwise a generated
+ * default ("WP1", "WP2", ... along a route, "DP" for a go-to position, "VP" for
+ * the vessel's starting point). This function forwards that name verbatim so
+ * the NMEA identifier always matches what the rest of Signal K displays; it
+ * never invents one. If the server supplies no name (an older server, or a
+ * route point with no metadata) the field is emitted empty rather than guessed.
  *
- * NMEA0183 reserves a few framing characters; we strip them defensively
- * in case `point.name` ever contains them.
+ * Names can be operator-defined, so they are sanitised before going on the
+ * wire. See `sanitize` below.
  */
 
 export interface CoursePoint {
@@ -22,65 +23,29 @@ export interface CoursePoint {
   href?: string | null
 }
 
-export interface ActiveRoute {
-  href?: string | null
-  name?: string | null
-  pointIndex?: number | null
-  pointTotal?: number | null
-}
-
-// Preserved for backward compatibility with callers that imported the
-// original `NextPoint` name; the shape is identical to CoursePoint.
+// `CoursePoint` is the shared shape of both course points; the sentence
+// encoders import it under the `NextPoint` alias (RMB re-aliases it again to
+// `PreviousPoint`) so each call site reads as the point it handles.
 export type NextPoint = CoursePoint
 
 const NMEA_RESERVED = /[,*$\r\n]/g
 const MAX_WAYPOINT_NAME_LEN = 20
 
 export function generateWaypointName(
-  point: CoursePoint | null | undefined,
-  activeRoute: ActiveRoute | null | undefined
+  point: CoursePoint | null | undefined
 ): string {
-  const p = point ?? {}
-  if (typeof p.name === 'string' && p.name.length > 0) {
-    return sanitize(p.name)
+  const name = point?.name
+  if (typeof name !== 'string') {
+    return ''
   }
-  return sanitize(synthesizeFallbackName(p, activeRoute ?? {}))
+  return sanitize(name)
 }
 
-/**
- * Pre-#2608 fallback: synthesize a default name from the point type.
- * Mirrors signalk-server's CourseAPI defaults so the NMEA output stays
- * consistent before and after #2608 lands:
- *
- *   RoutePoint     -> "WP<pointIndex+1>" (e.g. "WP1", "WP2", ...)
- *   Waypoint       -> "WP1"   (single-point goto-waypoint)
- *   Location       -> "DP"    (direct-to-position)
- *   VesselPosition -> "VP"    (previousPoint at start of any goto)
- *   (anything else)-> "WP1"   (last-ditch default matching upstream)
- *
- * REMOVE this function once SignalK/signalk-server#2608 is released and
- * point.name is reliably populated in the delta stream.
- */
-function synthesizeFallbackName(
-  point: CoursePoint,
-  activeRoute: ActiveRoute
-): string {
-  if (point.type === 'RoutePoint') {
-    if (typeof activeRoute.pointIndex === 'number') {
-      return `WP${activeRoute.pointIndex + 1}`
-    }
-    return 'WP1'
-  }
-  if (point.type === 'Location') {
-    return 'DP'
-  }
-  if (point.type === 'VesselPosition') {
-    return 'VP'
-  }
-  // Waypoint or unknown type
-  return 'WP1'
-}
-
+// NMEA0183 reserves ',', '*' and '$' for field/checksum framing and CR/LF as
+// the line terminator, so an operator-defined name containing any of them would
+// corrupt the sentence; strip those, then cap the length so a long name can't
+// overflow a receiver's fixed-width waypoint-ID field.
+// Example: "St *Tropez,1$" -> "St Tropez1"
 function sanitize(name: string): string {
   const stripped = name.replace(NMEA_RESERVED, '')
   return stripped.length > MAX_WAYPOINT_NAME_LEN

--- a/test/APB-true.ts
+++ b/test/APB-true.ts
@@ -128,17 +128,34 @@ describe('APB-true', function () {
     })
   })
 
-  it('falls back to "WP1" when nextPoint has no name and no route is active', (done) => {
-    // Route points and direct-to-position both arrive without a name (just a
-    // type and position). Empty field 10 confuses some chartplotters, so the
-    // generator emits "WP1" as a sensible single-point default. With an
-    // active multi-point route, "WP <pointIndex+1>" is used instead.
+  it('forwards a server default name (WP1) into field 10', (done) => {
+    // signalk-server fills nextPoint.name itself (e.g. "WP1" for the first
+    // point of a route, or a direct-to-waypoint with no resource name). The
+    // plugin forwards it unchanged.
+    const onEmit = (_event: string, value: unknown): void => {
+      const fields = parseApb(value as string)
+      assert.equal(fields.waypointId, 'WP1')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'APB-true')
+    pushApbStreams(app, {
+      nextPoint: {
+        position: { latitude: 25.04133, longitude: -77.24333 },
+        type: 'RoutePoint',
+        name: 'WP1'
+      }
+    })
+  })
+
+  it('leaves field 10 empty when nextPoint has no name', (done) => {
+    // Without a server-provided name the waypoint-ID field is emitted empty:
+    // the plugin forwards names but does not fabricate one.
     const onEmit = (_event: string, value: unknown): void => {
       const fields = parseApb(value as string)
       assert.equal(
         fields.waypointId,
-        'WP1',
-        'field 10 should default to "WP1" when no waypoint name is available'
+        '',
+        'field 10 should be empty when no waypoint name is available'
       )
       done()
     }

--- a/test/BWC-integration.ts
+++ b/test/BWC-integration.ts
@@ -9,7 +9,8 @@ import type { SignalKPlugin } from '../src/types/plugin'
 
 // Live snapshot captured from signalk-server's deltastream (vessel sailing
 // near Marsh Harbour, Bahamas, 9° W magnetic variation, 3-point route
-// "TO DELETE" active, currently heading to point 1 of 3).
+// "TO DELETE" active, currently heading to point 1 of 3). The server fills
+// nextPoint.name ("WP1" for the first route point); the plugin forwards it.
 const LIVE_SNAPSHOT = {
   datetime: '2026-05-08T19:32:22.000Z',
   nextPoint: {
@@ -17,14 +18,8 @@ const LIVE_SNAPSHOT = {
     position: {
       latitude: 26.547617287650734,
       longitude: -77.05992185300417
-    }
-  },
-  activeRoute: {
-    href: '/resources/routes/d12f9af7-8556-440c-984a-a9795693fc8d',
-    name: 'TO DELETE',
-    reverse: false,
-    pointIndex: 0,
-    pointTotal: 3
+    },
+    name: 'WP1'
   },
   bearingTrue: 5.890679316509219,
   bearingMagnetic: 5.729787364152641,
@@ -71,7 +66,6 @@ describe('BWC Integration', function () {
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
       LIVE_SNAPSHOT.nextPoint,
-      LIVE_SNAPSHOT.activeRoute,
       LIVE_SNAPSHOT.bearingTrue,
       LIVE_SNAPSHOT.bearingMagnetic,
       LIVE_SNAPSHOT.distance
@@ -88,7 +82,6 @@ describe('BWC Integration', function () {
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
       LIVE_SNAPSHOT.nextPoint,
-      LIVE_SNAPSHOT.activeRoute,
       LIVE_SNAPSHOT.bearingTrue,
       LIVE_SNAPSHOT.bearingMagnetic,
       LIVE_SNAPSHOT.distance
@@ -115,7 +108,7 @@ describe('BWC Integration', function () {
     assert.equal(
       fields[12],
       'WP1',
-      'waypoint ID synthesized as "WP <pointIndex+1>"'
+      'waypoint ID forwarded from server-provided nextPoint.name'
     )
   })
 
@@ -127,7 +120,6 @@ describe('BWC Integration', function () {
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
       LIVE_SNAPSHOT.nextPoint,
-      LIVE_SNAPSHOT.activeRoute,
       LIVE_SNAPSHOT.bearingTrue,
       null,
       LIVE_SNAPSHOT.distance
@@ -146,7 +138,6 @@ describe('BWC Integration', function () {
     const sentence = encoder.f(
       LIVE_SNAPSHOT.datetime,
       LIVE_SNAPSHOT.nextPoint,
-      LIVE_SNAPSHOT.activeRoute,
       LIVE_SNAPSHOT.bearingTrue,
       LIVE_SNAPSHOT.bearingMagnetic,
       LIVE_SNAPSHOT.distance

--- a/test/BWC.ts
+++ b/test/BWC.ts
@@ -14,21 +14,15 @@ type AnyApp = ReturnType<typeof createAppWithPlugin>
  */
 const LIVE_SNAPSHOT_1 = {
   datetime: '2026-05-08T19:32:22.000Z',
-  // navigation.course.nextPoint is published as a composite delta:
+  // navigation.course.nextPoint is published as a composite delta; the server
+  // fills `name` ("WP1" for the first route point) which BWC forwards.
   nextPoint: {
     type: 'RoutePoint',
     position: {
       latitude: 26.547617287650734,
       longitude: -77.05992185300417
-    }
-  },
-  // navigation.course.activeRoute is published as a composite delta:
-  activeRoute: {
-    href: '/resources/routes/d12f9af7-8556-440c-984a-a9795693fc8d',
-    name: 'TO DELETE',
-    reverse: false,
-    pointIndex: 0,
-    pointTotal: 3
+    },
+    name: 'WP1'
   },
   bearingTrue: 5.890679316509219, // 337.5° true
   bearingMagnetic: 5.729787364152641, // 328.3° magnetic
@@ -43,17 +37,9 @@ interface NextPointArg {
   name?: string
 }
 
-interface ActiveRouteArg {
-  href?: string | null
-  name?: string | null
-  pointIndex?: number | null
-  pointTotal?: number | null
-}
-
 interface BwcOverrides {
   datetime?: string
   nextPoint?: NextPointArg | null
-  activeRoute?: ActiveRouteArg
   bearingTrue?: number | undefined
   bearingMagnetic?: number | undefined | null
   distance?: number | undefined
@@ -68,15 +54,6 @@ function pushBwcStreams(app: AnyApp, overrides: BwcOverrides): void {
     .push(
       'nextPoint' in overrides ? overrides.nextPoint : LIVE_SNAPSHOT_1.nextPoint
     )
-  if ('activeRoute' in overrides) {
-    app.streambundle
-      .getSelfStream('navigation.course.activeRoute')
-      .push(overrides.activeRoute)
-  } else {
-    app.streambundle
-      .getSelfStream('navigation.course.activeRoute')
-      .push(LIVE_SNAPSHOT_1.activeRoute)
-  }
   app.streambundle
     .getSelfStream('navigation.course.calcValues.bearingTrue')
     .push(
@@ -223,9 +200,9 @@ describe('BWC', function () {
   })
 
   describe('waypoint ID derivation (field 12)', function () {
-    it('emits "WP <pointIndex+1>" for the first point of a multi-point route', (done) => {
+    it('forwards the server-provided name for the active route point', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        // pointIndex=0 → "WP1"
+        // LIVE_SNAPSHOT_1.nextPoint.name === "WP1"
         assert.equal(parseBwc(value as string).fields.waypointId, 'WP1')
         done()
       }
@@ -233,29 +210,22 @@ describe('BWC', function () {
       pushBwcStreams(app, {})
     })
 
-    it('emits "WP3" when pointIndex advances to the third leg', (done) => {
+    it('forwards a different server-provided name (WP3) verbatim', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
         assert.equal(parseBwc(value as string).fields.waypointId, 'WP3')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
       pushBwcStreams(app, {
-        activeRoute: { ...LIVE_SNAPSHOT_1.activeRoute, pointIndex: 2 }
+        nextPoint: {
+          type: 'RoutePoint',
+          position: LIVE_SNAPSHOT_1.nextPoint.position,
+          name: 'WP3'
+        }
       })
     })
 
-    it('emits "WP1" for a single-point route (does not use the route name)', (done) => {
-      const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.waypointId, 'WP1')
-        done()
-      }
-      const app = createAppWithPlugin(onEmit, 'BWC')
-      pushBwcStreams(app, {
-        activeRoute: { name: 'SOLO', pointIndex: 0, pointTotal: 1 }
-      })
-    })
-
-    it('prefers nextPoint.name when the server populates it (SignalK#2608)', (done) => {
+    it('forwards a custom server-provided waypoint name verbatim', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
         assert.equal(parseBwc(value as string).fields.waypointId, 'WP-A')
         done()
@@ -270,7 +240,7 @@ describe('BWC', function () {
       })
     })
 
-    it('emits "DP" for a Location-type destination with no route (goto navigation)', (done) => {
+    it('emits "DP" for a Location-type destination (goto navigation)', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
         assert.equal(parseBwc(value as string).fields.waypointId, 'DP')
         done()
@@ -279,24 +249,26 @@ describe('BWC', function () {
       pushBwcStreams(app, {
         nextPoint: {
           type: 'Location',
-          position: LIVE_SNAPSHOT_1.nextPoint.position
-        },
-        activeRoute: { href: null, name: null }
+          position: LIVE_SNAPSHOT_1.nextPoint.position,
+          name: 'DP'
+        }
       })
     })
 
-    it('emits "DP" when activeRoute stream is the {} default and nextPoint is a Location', (done) => {
+    it('emits an empty field 12 when the server omits the name', (done) => {
       const onEmit = (_event: string, value: unknown): void => {
-        assert.equal(parseBwc(value as string).fields.waypointId, 'DP')
+        const { fields, body, fieldCount, checksum } = parseBwc(value as string)
+        assert.equal(fields.waypointId, '')
+        assert.equal(fieldCount, 13, 'field still present, just empty')
+        assert.equal(checksum, xorChecksum(body), 'checksum still valid')
         done()
       }
       const app = createAppWithPlugin(onEmit, 'BWC')
       pushBwcStreams(app, {
         nextPoint: {
-          type: 'Location',
+          type: 'RoutePoint',
           position: LIVE_SNAPSHOT_1.nextPoint.position
-        },
-        activeRoute: {}
+        }
       })
     })
 
@@ -543,7 +515,7 @@ describe('BWC', function () {
   })
 
   describe('Signal K subscription metadata', function () {
-    it('subscribes to the six required Signal K paths in order', () => {
+    it('subscribes to the five required Signal K paths in order', () => {
       const stubApp = {
         streambundle: {
           getSelfStream: (): unknown => ({ toProperty: () => ({}) })
@@ -556,14 +528,13 @@ describe('BWC', function () {
       assert.deepStrictEqual(bwc.keys, [
         'navigation.datetime',
         'navigation.course.nextPoint',
-        'navigation.course.activeRoute',
         'navigation.course.calcValues.bearingTrue',
         'navigation.course.calcValues.bearingMagnetic',
         'navigation.course.calcValues.distance'
       ])
     })
 
-    it('seeds activeRoute with {} and bearingMagnetic with null so the combined stream fires', () => {
+    it('seeds bearingMagnetic with null so the combined stream fires', () => {
       const stubApp = {
         streambundle: {
           getSelfStream: (): unknown => ({ toProperty: () => ({}) })
@@ -576,7 +547,6 @@ describe('BWC', function () {
       assert.deepStrictEqual(bwc.defaults, [
         '',
         undefined,
-        {},
         undefined,
         null,
         undefined

--- a/test/RMB.ts
+++ b/test/RMB.ts
@@ -130,11 +130,11 @@ describe('RMB', function () {
     })
   })
 
-  it('synthesizes type-specific defaults when names are missing (DP/VP/WP1)', (done) => {
-    // Mirrors signalk-server #2608's defaults so behavior is consistent
-    // before and after that PR ships:
-    //   nextPoint type=Location, no name      -> "DP" (Destination Position)
-    //   previousPoint type=VesselPosition     -> "VP"
+  it('forwards the server-provided defaults for a goto (DP destination, VP origin)', (done) => {
+    // signalk-server fills nextPoint.name / previousPoint.name with its own
+    // defaults for a direct-to-position goto:
+    //   nextPoint type=Location          -> "DP" (Destination Position)
+    //   previousPoint type=VesselPosition -> "VP"
     const onEmit = (_event: string, value: unknown): void => {
       const fields = parseRmb(value as string)
       assert.equal(
@@ -153,7 +153,32 @@ describe('RMB', function () {
     pushRmbStreams(app, {
       nextPoint: {
         position: { latitude: 48.1173, longitude: 11.5167 },
-        type: 'Location'
+        type: 'Location',
+        name: 'DP'
+      },
+      previousPoint: {
+        position: { latitude: 47.3769, longitude: 8.5417 },
+        type: 'VesselPosition',
+        name: 'VP'
+      }
+    })
+  })
+
+  it('leaves the origin field empty when previousPoint has no name', (done) => {
+    // An unnamed previousPoint (e.g. from an older server) yields an empty
+    // FROM field: the plugin forwards names but does not fabricate one.
+    const onEmit = (_event: string, value: unknown): void => {
+      const fields = parseRmb(value as string)
+      assert.equal(fields.destinationId, 'DEST')
+      assert.equal(fields.originId, '', 'field 5 should be empty')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMB')
+    pushRmbStreams(app, {
+      nextPoint: {
+        position: { latitude: 48.1173, longitude: 11.5167 },
+        type: 'Waypoint',
+        name: 'DEST'
       },
       previousPoint: {
         position: { latitude: 47.3769, longitude: 8.5417 },

--- a/test/live-snapshots.ts
+++ b/test/live-snapshots.ts
@@ -11,9 +11,11 @@
  *   3. active-route          - multi-point route active, currently at point 1
  *
  * Each scenario asserts the routing sentences (RMB, APB, APB-true, XTE)
- * against the captured state. Pushes are ordered context-first (paths
- * with a default in the encoder) then trigger-last so the combined
- * stream's first fire already has all context populated.
+ * against the captured state. nextPoint / previousPoint carry the `name`
+ * that signalk-server populates (its own "WP<n>" / "DP" / "VP" defaults);
+ * the plugin forwards those into the waypoint-ID fields. Pushes are ordered
+ * context-first (paths with a default in the encoder) then trigger-last so
+ * the combined stream's first fire already has all context populated.
  *
  * Full snapshots are kept under test/snapshots/ for diagnostic re-runs
  * via scripts/probe-snapshot.ts; new scenarios can be captured with
@@ -41,14 +43,16 @@ const SCENARIO_NO_WAYPOINT: Scenario = {
         latitude: 26.54696714586578,
         longitude: -77.06287980079651
       },
-      type: 'Location'
+      type: 'Location',
+      name: 'DP'
     },
     'navigation.course.previousPoint': {
       position: {
         latitude: 26.546606666666666,
         longitude: -77.05950333333334
       },
-      type: 'VesselPosition'
+      type: 'VesselPosition',
+      name: 'VP'
     },
     'navigation.course.activeRoute': null,
     'navigation.magneticVariation': -0.16089135395421264
@@ -69,14 +73,16 @@ const SCENARIO_WAYPOINT: Scenario = {
         longitude: -77.06213951110841
       },
       href: '/resources/waypoints/c9dc41b2-1bce-4e7d-80f2-882aca7a3eae',
-      type: 'Waypoint'
+      type: 'Waypoint',
+      name: 'WP1'
     },
     'navigation.course.previousPoint': {
       position: {
         latitude: 26.546733333333332,
         longitude: -77.05952333333333
       },
-      type: 'VesselPosition'
+      type: 'VesselPosition',
+      name: 'VP'
     },
     'navigation.course.activeRoute': null,
     'navigation.magneticVariation': -0.16089135395421264
@@ -96,14 +102,16 @@ const SCENARIO_ROUTE: Scenario = {
       position: {
         latitude: 26.54661003894277,
         longitude: -77.06357717514038
-      }
+      },
+      name: 'WP1'
     },
     'navigation.course.previousPoint': {
       position: {
         latitude: 26.546718333333335,
         longitude: -77.05952833333333
       },
-      type: 'VesselPosition'
+      type: 'VesselPosition',
+      name: 'VP'
     },
     'navigation.course.activeRoute': {
       href: '/resources/routes/c1551d44-65dc-409d-b09a-7482202cc2a1',

--- a/test/metadata.ts
+++ b/test/metadata.ts
@@ -23,8 +23,7 @@ const expectations: Expectation[] = [
       'navigation.course.calcValues.bearingTrackTrue',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.nextPoint',
-      'navigation.magneticVariation',
-      'navigation.course.activeRoute'
+      'navigation.magneticVariation'
     ]
   },
   {
@@ -35,8 +34,7 @@ const expectations: Expectation[] = [
       'navigation.course.calcValues.crossTrackError',
       'navigation.course.calcValues.bearingTrackTrue',
       'navigation.course.calcValues.bearingTrue',
-      'navigation.course.nextPoint',
-      'navigation.course.activeRoute'
+      'navigation.course.nextPoint'
     ]
   },
   {
@@ -46,7 +44,6 @@ const expectations: Expectation[] = [
     keys: [
       'navigation.datetime',
       'navigation.course.nextPoint',
-      'navigation.course.activeRoute',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.calcValues.bearingMagnetic',
       'navigation.course.calcValues.distance'
@@ -233,8 +230,7 @@ const expectations: Expectation[] = [
       'navigation.course.calcValues.distance',
       'navigation.course.calcValues.bearingTrue',
       'navigation.course.calcValues.velocityMadeGood',
-      'navigation.course.previousPoint',
-      'navigation.course.activeRoute'
+      'navigation.course.previousPoint'
     ]
   },
   {

--- a/test/waypointNameGenerator.ts
+++ b/test/waypointNameGenerator.ts
@@ -3,110 +3,67 @@ import * as assert from 'assert'
 import { generateWaypointName } from '../src/waypointNameGenerator'
 
 describe('generateWaypointName', function () {
-  describe('priority: point.name wins over fallback', function () {
-    it('uses nextPoint.name when present', function () {
+  describe('forwards the server-provided point.name', function () {
+    it('returns the name verbatim when present', function () {
       assert.strictEqual(
-        generateWaypointName(
-          { name: 'NASSAU', type: 'Waypoint' },
-          { name: 'Bahamas Cruise', pointIndex: 2 }
-        ),
+        generateWaypointName({ name: 'NASSAU', type: 'Waypoint' }),
         'NASSAU'
       )
     })
-  })
 
-  describe('RoutePoint fallback uses activeRoute.pointIndex', function () {
-    it('synthesizes "WP1" for pointIndex 0', function () {
+    it('forwards the server defaults unchanged (WP<n> / DP / VP)', function () {
+      // signalk-server fills these defaults itself; the plugin passes them through.
       assert.strictEqual(
-        generateWaypointName(
-          { type: 'RoutePoint' },
-          { name: 'Bahamas', pointIndex: 0 }
-        ),
-        'WP1'
+        generateWaypointName({ name: 'WP2', type: 'RoutePoint' }),
+        'WP2'
       )
-    })
-    it('synthesizes "WP3" for pointIndex 2', function () {
       assert.strictEqual(
-        generateWaypointName({ type: 'RoutePoint' }, { pointIndex: 2 }),
-        'WP3'
+        generateWaypointName({ name: 'DP', type: 'Location' }),
+        'DP'
       )
-    })
-    it('synthesizes "WP6" for pointIndex 5 even without route name', function () {
       assert.strictEqual(
-        generateWaypointName({ type: 'RoutePoint' }, { pointIndex: 5 }),
-        'WP6'
-      )
-    })
-    it('falls back to "WP1" for RoutePoint when pointIndex is missing', function () {
-      assert.strictEqual(
-        generateWaypointName({ type: 'RoutePoint' }, null),
-        'WP1'
-      )
-    })
-  })
-
-  describe('type-specific defaults (mirrors signalk-server #2608)', function () {
-    it('returns "DP" for direct-to-Location', function () {
-      assert.strictEqual(generateWaypointName({ type: 'Location' }, null), 'DP')
-    })
-    it('returns "VP" for previous VesselPosition', function () {
-      assert.strictEqual(
-        generateWaypointName({ type: 'VesselPosition' }, null),
+        generateWaypointName({ name: 'VP', type: 'VesselPosition' }),
         'VP'
       )
     })
-    it('returns "WP1" for direct-to-Waypoint with no name', function () {
-      assert.strictEqual(
-        generateWaypointName(
-          { type: 'Waypoint', href: '/resources/waypoints/abc-123' },
-          null
-        ),
-        'WP1'
-      )
+  })
+
+  describe('returns an empty string when no name is available', function () {
+    it('empty for a typed point with no name', function () {
+      assert.strictEqual(generateWaypointName({ type: 'RoutePoint' }), '')
     })
-    it('returns "WP1" for unknown / missing type', function () {
-      assert.strictEqual(generateWaypointName({}, null), 'WP1')
+
+    it('empty for an empty object', function () {
+      assert.strictEqual(generateWaypointName({}), '')
     })
-    it('returns "WP1" for null nextPoint and null activeRoute', function () {
-      assert.strictEqual(generateWaypointName(null, null), 'WP1')
+
+    it('empty for null', function () {
+      assert.strictEqual(generateWaypointName(null), '')
+    })
+
+    it('empty for undefined', function () {
+      assert.strictEqual(generateWaypointName(undefined), '')
+    })
+
+    it('empty when name is an empty string', function () {
+      assert.strictEqual(generateWaypointName({ name: '' }), '')
     })
   })
 
   describe('NMEA framing-character defenses', function () {
     it('strips comma, asterisk, dollar, CR, LF from name', function () {
       assert.strictEqual(
-        generateWaypointName({ name: 'A,B*C$D\rE\nF' }, null),
+        generateWaypointName({ name: 'A,B*C$D\rE\nF' }),
         'ABCDEF'
       )
     })
+
     it('truncates names longer than 20 characters', function () {
       assert.strictEqual(
-        generateWaypointName(
-          { name: 'A_VERY_LONG_WAYPOINT_NAME_THAT_OVERFLOWS' },
-          null
-        ),
+        generateWaypointName({
+          name: 'A_VERY_LONG_WAYPOINT_NAME_THAT_OVERFLOWS'
+        }),
         'A_VERY_LONG_WAYPOINT'
-      )
-    })
-  })
-
-  describe('robustness against partial/undefined inputs', function () {
-    it('treats undefined nextPoint as empty object', function () {
-      assert.strictEqual(
-        generateWaypointName(undefined, { pointIndex: 0 }),
-        'WP1'
-      )
-    })
-    it('treats undefined activeRoute as empty object', function () {
-      assert.strictEqual(generateWaypointName({ name: 'X' }, undefined), 'X')
-    })
-    it('ignores non-numeric pointIndex (falls back to type default)', function () {
-      assert.strictEqual(
-        generateWaypointName(
-          { type: 'RoutePoint' },
-          { pointIndex: '1' as unknown as number }
-        ),
-        'WP1'
       )
     })
   })


### PR DESCRIPTION
## Summary

signalk-server now populates `nextPoint.name` / `previousPoint.name` on the
course delta ([SignalK/signalk-server#2608](https://github.com/SignalK/signalk-server/pull/2608),
merged), supplying its own `WP<n>` / `DP` / `VP` defaults for routes,
goto-waypoint and goto-position navigation alike.

This plugin previously carried a client-side fallback that mirrored those
defaults by synthesizing a name from `activeRoute.pointIndex`. That fallback
is now redundant, so the plugin forwards the server-provided `name` verbatim
for RMB, APB, APB-true and BWC.

## Changes

- `generateWaypointName` now just forwards `point.name` (still strips the NMEA
  framing characters `, * $ CR LF` and caps the length at 20); the
  `synthesizeFallbackName` logic and the `ActiveRoute` type are removed.
- Dropped the `navigation.course.activeRoute` subscription (key, default and
  handler parameter) from RMB, APB, APB-true and BWC, since it was used only
  for name synthesis.
- Confirmed go-to navigation (waypoint or coordinate) works: the server fills
  `DP` for a direct-to-position and the waypoint name (or `WP1`) for a
  direct-to-waypoint, and the plugin forwards both.
- README: added the missing BWC entry and a note on where the waypoint
  identifier now comes from.

## Behavior note

When the server omits the name (older servers, pre-#2608) the identifier field
is left empty instead of synthesized. Against a current Signal K server the
field is always filled.

## Testing

- `npm run typecheck`, `npm run build`, `npm run prettier:check`: clean.
- `npm test`: 367 passing. Fixtures (unit tests, the live-snapshot regression
  scenarios and the BWC integration snapshot) updated to carry the
  server-provided `name`, matching the latest server.

Closes #189
