### PR TITLE
fix: Update Heading group sentences

### DIFF
--- a/src/sentences/HDG.ts
+++ b/src/sentences/HDG.ts
@@ -67,8 +67,8 @@ export default function (_app: SignalKApp): SentenceEncoder {
         '', // deviation — always empty (already applied in SK)
         '', // deviation direction — always empty
         variationDeg,
-        variationDir,
+        variationDir
       ])
-    },
+    }
   }
 }

--- a/src/sentences/HDG.ts
+++ b/src/sentences/HDG.ts
@@ -1,50 +1,74 @@
 /*
-HDG - Heading, Deviation & Variation
-
-       0   1   2 3   4
-       |   |   | |   |
-$--HDG,x.x,x.x,a,x.x,a*hh<CR><LF>
-
-Field Number:
-0 Magnetic Sensor heading in degrees
-1 Magnetic Deviation, degrees
-2 Magnetic Deviation direction, E = Easterly, W = Westerly
-3 Magnetic Variation degrees
-4 Magnetic Variation direction, E = Easterly, W = Westerly
-*/
+ * HDG - Heading, Deviation & Variation
+ *
+ *        0   1   2 3   4
+ *        |   |   | |   |
+ * $--HDG,x.x,x.x,a,x.x,a*hh<CR><LF>
+ *
+ * Field 0: Magnetic sensor heading in degrees
+ * Field 1: Magnetic deviation, degrees  (always empty — Signal K's
+ *           headingMagnetic already has deviation applied)
+ * Field 2: Deviation direction E/W      (always empty for the same reason)
+ * Field 3: Magnetic variation, degrees
+ * Field 4: Variation direction E/W
+ *
+ * Signal K inputs and priority rules
+ * -----------------------------------
+ * navigation.headingMagnetic  — required; sentence is suppressed without it.
+ * navigation.magneticVariation — optional; fields 3-4 are left empty when
+ *   absent (strict NMEA: both the value and the direction indicator are
+ *   omitted so chartplotters see a cleanly empty field pair).
+ *
+ * Example: $IIHDG,201.10,,,9.00,E*16
+ */
 
 import * as nmea from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
+
+const MISSING = '' as const
+type MaybeNumber = number | typeof MISSING
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {
     sentence: 'HDG',
     title: 'HDG - Heading, Deviation & Variation',
     keys: ['navigation.headingMagnetic', 'navigation.magneticVariation'],
-    defaults: [undefined, ''],
+    // headingMagnetic has no default — the sentence is suppressed until it
+    // emits at least once.  magneticVariation defaults to MISSING so the
+    // combined stream can fire even when variation is not yet available.
+    defaults: [undefined, MISSING],
     f: function hdg(
       headingMagnetic: number,
-      magneticVariation: number | ''
-    ): string {
-      let magneticVariationDeg = ''
-      let magneticVariationDir = ''
-      if (magneticVariation !== '') {
-        magneticVariationDir = 'E'
+      magneticVariation: MaybeNumber
+    ): string | undefined {
+      // headingMagnetic is required; without it there is nothing to emit.
+      // (The stream will not fire at all until headingMagnetic emits, but
+      // a runtime guard keeps the type system happy and adds robustness.)
+      if ((headingMagnetic as MaybeNumber) === MISSING) {
+        return undefined
+      }
+
+      // Variation: emit value + direction, or leave both fields empty.
+      let variationDeg = ''
+      let variationDir = ''
+      if (magneticVariation !== MISSING) {
         if (magneticVariation < 0) {
-          magneticVariationDir = 'W'
-          magneticVariation = Math.abs(magneticVariation)
+          variationDir = 'W'
+          variationDeg = nmea.radsToDeg(Math.abs(magneticVariation)).toFixed(2)
+        } else {
+          variationDir = 'E'
+          variationDeg = nmea.radsToDeg(magneticVariation).toFixed(2)
         }
-        magneticVariationDeg = nmea.radsToDeg(magneticVariation).toFixed(2)
       }
 
       return nmea.toSentence([
         '$IIHDG',
         nmea.radsToPositiveDeg(headingMagnetic).toFixed(2),
-        '',
-        '',
-        magneticVariationDeg,
-        magneticVariationDir
+        '', // deviation — always empty (already applied in SK)
+        '', // deviation direction — always empty
+        variationDeg,
+        variationDir,
       ])
-    }
+    },
   }
 }

--- a/src/sentences/HDM.ts
+++ b/src/sentences/HDM.ts
@@ -1,4 +1,20 @@
-// NMEA0183 Encoder HDM   $IIHDM,206.7,M*21
+/*
+ * HDM - Heading, Magnetic
+ *
+ * $--HDM,x.x,M*hh<CR><LF>
+ *
+ * Field 0: Heading in degrees, magnetic
+ * Field 1: M (magnetic)
+ *
+ * Signal K input
+ * --------------
+ * navigation.headingMagnetic — required; no default.  When it has not
+ * emitted the combined stream does not fire and no sentence is produced.
+ * This is correct: a partial HDM sentence (empty heading) has no value.
+ *
+ * Example: $IIHDM,206.7,M*21
+ */
+
 import * as nmea from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
 
@@ -7,12 +23,13 @@ export default function (_app: SignalKApp): SentenceEncoder {
     sentence: 'HDM',
     title: 'HDM - Heading Magnetic',
     keys: ['navigation.headingMagnetic'],
-    f: function (heading: number): string {
+    // No default: the sentence is meaningless without the heading value.
+    f: function hdm(heading: number): string {
       return nmea.toSentence([
         '$IIHDM',
         nmea.radsToPositiveDeg(heading).toFixed(1),
-        'M'
+        'M',
       ])
-    }
+    },
   }
 }

--- a/src/sentences/HDM.ts
+++ b/src/sentences/HDM.ts
@@ -28,8 +28,8 @@ export default function (_app: SignalKApp): SentenceEncoder {
       return nmea.toSentence([
         '$IIHDM',
         nmea.radsToPositiveDeg(heading).toFixed(1),
-        'M',
+        'M'
       ])
-    },
+    }
   }
 }

--- a/src/sentences/HDMC.ts
+++ b/src/sentences/HDMC.ts
@@ -49,8 +49,8 @@ export default function (_app: SignalKApp): SentenceEncoder {
       return nmea.toSentence([
         '$IIHDM',
         nmea.radsToPositiveDeg(headingTrue - magneticVariation).toFixed(1),
-        'M',
+        'M'
       ])
-    },
+    }
   }
 }

--- a/src/sentences/HDMC.ts
+++ b/src/sentences/HDMC.ts
@@ -1,19 +1,56 @@
-// NMEA0183 Encoder HDMC   $IIHDM,212.2,M*21
+/*
+ * HDMC - HDM sentence calculated from True heading and Variation
+ *
+ * Produces a standard $IIHDM sentence but derives the magnetic heading
+ * from Signal K's navigation.headingTrue and navigation.magneticVariation
+ * rather than from a magnetic sensor directly.
+ *
+ * Per the Signal K spec:
+ *   headingMagnetic = headingTrue − magneticVariation
+ *
+ * $--HDM,x.x,M*hh<CR><LF>
+ *
+ * Signal K inputs
+ * ---------------
+ * navigation.headingTrue       — required; defaults to MISSING.
+ * navigation.magneticVariation — required; defaults to MISSING.
+ *
+ * Both inputs must be present to compute the magnetic heading.  If either
+ * is absent the sentence is suppressed (return undefined) because there is
+ * no partial value worth emitting.
+ *
+ * Example: $IIHDM,170.0,M*24
+ */
+
 import * as nmea from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
+
+const MISSING = '' as const
+type MaybeNumber = number | typeof MISSING
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {
     sentence: 'HDM',
     title: 'HDM - Heading Magnetic, calculated from True',
     keys: ['navigation.headingTrue', 'navigation.magneticVariation'],
-    f: function (headingTrue: number, magneticVariation: number): string {
-      const heading = headingTrue - magneticVariation
+    // Both paths default to MISSING so the combined stream fires as soon
+    // as either emits.  The guard in f() suppresses output until both
+    // have real values.
+    defaults: [MISSING, MISSING],
+    f: function hdmc(
+      headingTrue: MaybeNumber,
+      magneticVariation: MaybeNumber
+    ): string | undefined {
+      // Both inputs are required to compute a meaningful magnetic heading.
+      if (headingTrue === MISSING || magneticVariation === MISSING) {
+        return undefined
+      }
+
       return nmea.toSentence([
         '$IIHDM',
-        nmea.radsToPositiveDeg(heading).toFixed(1),
-        'M'
+        nmea.radsToPositiveDeg(headingTrue - magneticVariation).toFixed(1),
+        'M',
       ])
-    }
+    },
   }
 }

--- a/src/sentences/HDT.ts
+++ b/src/sentences/HDT.ts
@@ -1,4 +1,23 @@
-// NMEA0183 Encoder HDT   $IIHDT,200.1,T*21
+/*
+ * HDT - Heading, True
+ *
+ * $--HDT,x.x,T*hh<CR><LF>
+ *
+ * Field 0: Heading in degrees, true
+ * Field 1: T (true)
+ *
+ * Signal K input
+ * --------------
+ * navigation.headingTrue — required; no default.  When it has not emitted
+ * the combined stream does not fire and no sentence is produced.
+ * This is correct: a partial HDT sentence (empty heading) has no value.
+ *
+ * If you need true heading derived from magnetic + variation, use HDTC
+ * instead; HDT is strictly for cases where a true-heading sensor is present.
+ *
+ * Example: $IIHDT,200.1,T*21
+ */
+
 import * as nmea from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
 
@@ -7,12 +26,13 @@ export default function (_app: SignalKApp): SentenceEncoder {
     sentence: 'HDT',
     title: 'HDT - Heading True',
     keys: ['navigation.headingTrue'],
-    f: function (heading: number): string {
+    // No default: the sentence is meaningless without the heading value.
+    f: function hdt(heading: number): string {
       return nmea.toSentence([
         '$IIHDT',
         nmea.radsToPositiveDeg(heading).toFixed(1),
-        'T'
+        'T',
       ])
-    }
+    },
   }
 }

--- a/src/sentences/HDT.ts
+++ b/src/sentences/HDT.ts
@@ -31,8 +31,8 @@ export default function (_app: SignalKApp): SentenceEncoder {
       return nmea.toSentence([
         '$IIHDT',
         nmea.radsToPositiveDeg(heading).toFixed(1),
-        'T',
+        'T'
       ])
-    },
+    }
   }
 }

--- a/src/sentences/HDTC.ts
+++ b/src/sentences/HDTC.ts
@@ -49,8 +49,8 @@ export default function (_app: SignalKApp): SentenceEncoder {
       return nmea.toSentence([
         '$IIHDT',
         nmea.radsToPositiveDeg(headingMagnetic + magneticVariation).toFixed(1),
-        'T',
+        'T'
       ])
-    },
+    }
   }
 }

--- a/src/sentences/HDTC.ts
+++ b/src/sentences/HDTC.ts
@@ -1,19 +1,56 @@
-// NMEA0183 Encoder HDT   $IIHDT,200.1,T*21
+/*
+ * HDTC - HDT sentence calculated from Magnetic heading and Variation
+ *
+ * Produces a standard $IIHDT sentence but derives the true heading from
+ * Signal K's navigation.headingMagnetic and navigation.magneticVariation
+ * rather than from a true-north sensor directly.
+ *
+ * Per the Signal K spec:
+ *   headingTrue = headingMagnetic + magneticVariation
+ *
+ * $--HDT,x.x,T*hh<CR><LF>
+ *
+ * Signal K inputs
+ * ---------------
+ * navigation.headingMagnetic   — required; defaults to MISSING.
+ * navigation.magneticVariation — required; defaults to MISSING.
+ *
+ * Both inputs must be present to compute the true heading.  If either
+ * is absent the sentence is suppressed (return undefined) because there is
+ * no partial value worth emitting.
+ *
+ * Example: $IIHDT,180.0,T*2B
+ */
+
 import * as nmea from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
+
+const MISSING = '' as const
+type MaybeNumber = number | typeof MISSING
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {
     sentence: 'HDTC',
     title: 'HDT - Heading True calculated from magnetic heading and variation',
     keys: ['navigation.headingMagnetic', 'navigation.magneticVariation'],
-    f: function (headingMagnetic: number, magneticVariation: number): string {
-      const heading = headingMagnetic + magneticVariation
+    // Both paths default to MISSING so the combined stream fires as soon
+    // as either emits.  The guard in f() suppresses output until both
+    // have real values.
+    defaults: [MISSING, MISSING],
+    f: function hdtc(
+      headingMagnetic: MaybeNumber,
+      magneticVariation: MaybeNumber
+    ): string | undefined {
+      // Both inputs are required to compute a meaningful true heading.
+      if (headingMagnetic === MISSING || magneticVariation === MISSING) {
+        return undefined
+      }
+
       return nmea.toSentence([
         '$IIHDT',
-        nmea.radsToPositiveDeg(heading).toFixed(1),
-        'T'
+        nmea.radsToPositiveDeg(headingMagnetic + magneticVariation).toFixed(1),
+        'T',
       ])
-    }
+    },
   }
 }

--- a/test/HDG.ts
+++ b/test/HDG.ts
@@ -104,4 +104,13 @@ describe('HDG', function () {
       done
     )
   })
+
+  // headingMagnetic is required; without it there is nothing to emit.
+  // (The stream will not fire at all until headingMagnetic emits, but a
+  // runtime guard keeps the type system happy and adds robustness.)
+
+  it('does not emit when headingMagnetic has not been pushed', (done) => {
+    // No paths at all — stream must not fire
+    testSuppressed('HDG', [], done)
+  })
 })

--- a/test/HDG.ts
+++ b/test/HDG.ts
@@ -1,75 +1,107 @@
-import * as assert from 'assert'
+import { testSequential, testSuppressed } from './testutil'
 
-import { createAppWithPlugin } from './testutil'
+/**
+ * HDG - Heading, Deviation & Variation
+ *
+ * $IIHDG,heading,,,variation,varDir*cs
+ *
+ * Field layout:
+ *   0  Magnetic sensor heading (degrees)
+ *   1  Magnetic deviation      — always empty (deviation already applied in SK)
+ *   2  Deviation direction     — always empty
+ *   3  Magnetic variation (degrees, absolute value)
+ *   4  Variation direction: E (positive) or W (negative)
+ *
+ * navigation.headingMagnetic is required (no default); the sentence is
+ * suppressed until it emits.  navigation.magneticVariation is optional;
+ * when absent, fields 3-4 are both left empty (strict NMEA).
+ *
+ * Checksums were pre-computed and verified independently.
+ * See test/testutil.ts for the BaconJS timing rationale behind testSequential.
+ */
 
-// Multi-input sentence with mixed defaults: navigation.headingMagnetic has
-// no default, navigation.magneticVariation defaults to ''. This exercises
-// combineStreamsWith with one Property (toProperty(default)) plus one
-// non-defaulted Bus that we then push to.
-//
-// HDG field layout: $--HDG,heading,deviation,devDir,variation,varDir*cs
-// Deviation fields (1-2) are always empty because Signal K's
-// headingMagnetic already has deviation applied.
+const deg = (d: number): number => (d * Math.PI) / 180
+
 describe('HDG', function () {
+  this.timeout(300)
+
+  // ── headingMagnetic only ─────────────────────────────────────────────────
+
   it('emits heading with empty deviation and variation when only headingMagnetic is pushed', (done) => {
-    const onEmit = (_event: string, value: unknown): void => {
-      // 0.5 rad = 28.65 deg; no variation available
-      // Expected: $IIHDG,28.65,,,,*cs
-      assert.match(value as string, /^\$IIHDG,28\.65,,,,\*[0-9A-F]{2}$/)
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'HDG')
-    app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
+    // 0.5 rad ≈ 28.65°; no variation available → fields 3-4 both empty
+    // $IIHDG,28.65,,,,*40
+    testSequential(
+      'HDG',
+      [{ path: 'navigation.headingMagnetic', value: 0.5 }],
+      '$IIHDG,28.65,,,,*40',
+      done
+    )
   })
 
-  it('places easterly variation in fields 4-5', (done) => {
-    const onEmit = (_event: string, value: unknown): void => {
-      // headingMagnetic = 0.5 rad = 28.65 deg
-      // magneticVariation = 0.1 rad = 5.73 deg E
-      // Expected: $IIHDG,28.65,,,5.73,E*cs
-      // Push magneticVariation BEFORE headingMagnetic so the first
-      // combineWith emission already sees the non-default value
-      // (debounceImmediate(20) would swallow a second emission).
-      assert.match(value as string, /^\$IIHDG,28\.65,,,5\.73,E\*[0-9A-F]{2}$/)
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'HDG')
-    app.streambundle.getSelfStream('navigation.magneticVariation').push(0.1)
-    app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
+  it('handles heading near 360°', (done) => {
+    // 6.0 rad ≈ 343.77°
+    // $IIHDG,343.77,,,,*7D
+    testSequential(
+      'HDG',
+      [{ path: 'navigation.headingMagnetic', value: 6.0 }],
+      '$IIHDG,343.77,,,,*7D',
+      done
+    )
   })
 
-  it('places westerly variation in fields 4-5 with W direction', (done) => {
-    const onEmit = (_event: string, value: unknown): void => {
-      // magneticVariation = -0.1 rad (westerly, negative per Signal K spec)
-      // Expected: direction = 'W', degrees = 5.73 (absolute value)
-      // Expected: $IIHDG,28.65,,,5.73,W*cs
-      assert.match(value as string, /^\$IIHDG,28\.65,,,5\.73,W\*[0-9A-F]{2}$/)
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'HDG')
-    app.streambundle.getSelfStream('navigation.magneticVariation').push(-0.1)
-    app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
+  // ── headingMagnetic + variation ──────────────────────────────────────────
+
+  it('places easterly variation in fields 3-4', (done) => {
+    // headingMagnetic=0.5 rad ≈ 28.65°, variation=0.1 rad ≈ 5.73° E
+    // $IIHDG,28.65,,,5.73,E*1A
+    testSequential(
+      'HDG',
+      [
+        { path: 'navigation.magneticVariation', value: 0.1 },
+        { path: 'navigation.headingMagnetic', value: 0.5 },
+      ],
+      '$IIHDG,28.65,,,5.73,E*1A',
+      done
+    )
   })
 
-  it('handles heading near 360 degrees', (done) => {
-    const onEmit = (_event: string, value: unknown): void => {
-      // 6.0 rad = 343.77 deg
-      assert.match(value as string, /^\$IIHDG,343\.77,,,,\*[0-9A-F]{2}$/)
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'HDG')
-    app.streambundle.getSelfStream('navigation.headingMagnetic').push(6.0)
+  it('places westerly variation in fields 3-4 with W direction', (done) => {
+    // magneticVariation=-0.1 rad (negative = westerly per Signal K spec)
+    // → absolute value 5.73°, direction W
+    // $IIHDG,28.65,,,5.73,W*08
+    testSequential(
+      'HDG',
+      [
+        { path: 'navigation.magneticVariation', value: -0.1 },
+        { path: 'navigation.headingMagnetic', value: 0.5 },
+      ],
+      '$IIHDG,28.65,,,5.73,W*08',
+      done
+    )
   })
 
   it('handles zero variation as easterly', (done) => {
-    const onEmit = (_event: string, value: unknown): void => {
-      // magneticVariation = 0 rad; 0 !== '' is true, 0 < 0 is false => 'E'
-      // Expected: $IIHDG,28.65,,,0.00,E*cs
-      assert.match(value as string, /^\$IIHDG,28\.65,,,0\.00,E\*[0-9A-F]{2}$/)
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'HDG')
-    app.streambundle.getSelfStream('navigation.magneticVariation').push(0)
-    app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
+    // variation=0 → not negative, so direction is E, degrees 0.00
+    // $IIHDG,28.65,,,0.00,E*1B
+    testSequential(
+      'HDG',
+      [
+        { path: 'navigation.magneticVariation', value: 0 },
+        { path: 'navigation.headingMagnetic', value: 0.5 },
+      ],
+      '$IIHDG,28.65,,,0.00,E*1B',
+      done
+    )
+  })
+
+  // ── suppression ──────────────────────────────────────────────────────────
+
+  it('does not emit when only magneticVariation is present (headingMagnetic required)', (done) => {
+    // headingMagnetic has no default — the sentence must not fire without it
+    testSuppressed(
+      'HDG',
+      [{ path: 'navigation.magneticVariation', value: deg(10) }],
+      done
+    )
   })
 })

--- a/test/HDG.ts
+++ b/test/HDG.ts
@@ -58,7 +58,7 @@ describe('HDG', function () {
       'HDG',
       [
         { path: 'navigation.magneticVariation', value: 0.1 },
-        { path: 'navigation.headingMagnetic', value: 0.5 },
+        { path: 'navigation.headingMagnetic', value: 0.5 }
       ],
       '$IIHDG,28.65,,,5.73,E*1A',
       done
@@ -73,7 +73,7 @@ describe('HDG', function () {
       'HDG',
       [
         { path: 'navigation.magneticVariation', value: -0.1 },
-        { path: 'navigation.headingMagnetic', value: 0.5 },
+        { path: 'navigation.headingMagnetic', value: 0.5 }
       ],
       '$IIHDG,28.65,,,5.73,W*08',
       done
@@ -87,7 +87,7 @@ describe('HDG', function () {
       'HDG',
       [
         { path: 'navigation.magneticVariation', value: 0 },
-        { path: 'navigation.headingMagnetic', value: 0.5 },
+        { path: 'navigation.headingMagnetic', value: 0.5 }
       ],
       '$IIHDG,28.65,,,0.00,E*1B',
       done

--- a/test/HDM.ts
+++ b/test/HDM.ts
@@ -1,18 +1,55 @@
-import * as assert from 'assert'
+import { testSequential, testSuppressed } from './testutil'
 
-import { createAppWithPlugin } from './testutil'
+/**
+ * HDM - Heading, Magnetic
+ *
+ * $IIHDM,x.x,M*hh
+ *
+ * navigation.headingMagnetic is the only input and carries no default.
+ * Without it the combined stream never fires and no sentence is produced.
+ *
+ * Checksums were pre-computed and verified independently.
+ * See test/testutil.ts for the BaconJS timing rationale behind testSequential.
+ */
 
-// A second single-key sentence (alongside DBT) to exercise the same
-// combineStreamsWith single-input → .toProperty → .changes path with a
-// different encoder shape.
 describe('HDM', function () {
+  // ── normal emission ──────────────────────────────────────────────────────
+
   it('emits heading magnetic in degrees', (done) => {
-    const onEmit = (_event: string, value: unknown): void => {
-      // 0.5 rad ≈ 28.6 deg → $IIHDM,28.6,M*<cs>
-      assert.match(value as string, /^\$IIHDM,28\.6,M\*[0-9A-F]{2}$/)
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'HDM')
-    app.streambundle.getSelfStream('navigation.headingMagnetic').push(0.5)
+    // 0.5 rad ≈ 28.6°  →  $IIHDM,28.6,M*1E
+    testSequential(
+      'HDM',
+      [{ path: 'navigation.headingMagnetic', value: 0.5 }],
+      '$IIHDM,28.6,M*1E',
+      done
+    )
+  })
+
+  it('wraps heading above 360° into [0, 360)', (done) => {
+    // 2π + 0.5 rad should give the same result as 0.5 rad
+    // $IIHDM,28.6,M*1E
+    testSequential(
+      'HDM',
+      [{ path: 'navigation.headingMagnetic', value: 2 * Math.PI + 0.5 }],
+      '$IIHDM,28.6,M*1E',
+      done
+    )
+  })
+
+  it('wraps negative heading into [0, 360)', (done) => {
+    // -0.5 rad → 360 - 28.6 = 331.4°  →  $IIHDM,331.4,M*27
+    testSequential(
+      'HDM',
+      [{ path: 'navigation.headingMagnetic', value: -0.5 }],
+      '$IIHDM,331.4,M*27',
+      done
+    )
+  })
+
+  // ── suppression ──────────────────────────────────────────────────────────
+
+  it('does not emit when headingMagnetic has not been pushed', (done) => {
+    // No paths at all — stream must not fire
+    testSuppressed('HDM', [], done)
   })
 })

--- a/test/HDMC.ts
+++ b/test/HDMC.ts
@@ -28,7 +28,7 @@ describe('HDMC', function () {
       'HDMC',
       [
         { path: 'navigation.magneticVariation', value: deg(10) },
-        { path: 'navigation.headingTrue', value: Math.PI },
+        { path: 'navigation.headingTrue', value: Math.PI }
       ],
       '$IIHDM,170.0,M*24',
       done
@@ -42,7 +42,7 @@ describe('HDMC', function () {
       'HDMC',
       [
         { path: 'navigation.magneticVariation', value: deg(10) },
-        { path: 'navigation.headingTrue', value: deg(5) },
+        { path: 'navigation.headingTrue', value: deg(5) }
       ],
       '$IIHDM,355.0,M*21',
       done
@@ -56,7 +56,7 @@ describe('HDMC', function () {
       'HDMC',
       [
         { path: 'navigation.magneticVariation', value: deg(-10) },
-        { path: 'navigation.headingTrue', value: deg(355) },
+        { path: 'navigation.headingTrue', value: deg(355) }
       ],
       '$IIHDM,5.0,M*27',
       done

--- a/test/HDT.ts
+++ b/test/HDT.ts
@@ -1,0 +1,55 @@
+import { testSequential, testSuppressed } from './testutil'
+
+/**
+ * HDT - Heading, True
+ *
+ * $IIHDT,x.x,T*hh
+ *
+ * navigation.headingTrue is the only input and carries no default.
+ * Without it the combined stream never fires and no sentence is produced.
+ * For derived true heading (from magnetic + variation) use HDTC instead.
+ *
+ * Checksums were pre-computed and verified independently.
+ * See test/testutil.ts for the BaconJS timing rationale behind testSequential.
+ */
+
+describe('HDT', function () {
+  // ── normal emission ──────────────────────────────────────────────────────
+
+  it('emits heading true in degrees', (done) => {
+    // pi rad = 180.0°  →  $IIHDT,180.0,T*2B
+    testSequential(
+      'HDT',
+      [{ path: 'navigation.headingTrue', value: Math.PI }],
+      '$IIHDT,180.0,T*2B',
+      done
+    )
+  })
+
+  it('emits the example from the source comment', (done) => {
+    // 200.1° in radians
+    // $IIHDT,200.1,T*21
+    testSequential(
+      'HDT',
+      [{ path: 'navigation.headingTrue', value: (200.1 * Math.PI) / 180 }],
+      '$IIHDT,200.1,T*21',
+      done
+    )
+  })
+
+  it('wraps heading above 360° into [0, 360)', (done) => {
+    // 2π + π = 3π rad → 180.0°  →  $IIHDT,180.0,T*2B
+    testSequential(
+      'HDT',
+      [{ path: 'navigation.headingTrue', value: 3 * Math.PI }],
+      '$IIHDT,180.0,T*2B',
+      done
+    )
+  })
+
+  // ── suppression ──────────────────────────────────────────────────────────
+
+  it('does not emit when headingTrue has not been pushed', (done) => {
+    testSuppressed('HDT', [], done)
+  })
+})

--- a/test/HDTC.ts
+++ b/test/HDTC.ts
@@ -28,7 +28,7 @@ describe('HDTC', function () {
       'HDTC',
       [
         { path: 'navigation.magneticVariation', value: deg(10) },
-        { path: 'navigation.headingMagnetic', value: deg(170) },
+        { path: 'navigation.headingMagnetic', value: deg(170) }
       ],
       '$IIHDT,180.0,T*2B',
       done
@@ -42,7 +42,7 @@ describe('HDTC', function () {
       'HDTC',
       [
         { path: 'navigation.magneticVariation', value: deg(10) },
-        { path: 'navigation.headingMagnetic', value: deg(355) },
+        { path: 'navigation.headingMagnetic', value: deg(355) }
       ],
       '$IIHDT,5.0,T*27',
       done
@@ -56,7 +56,7 @@ describe('HDTC', function () {
       'HDTC',
       [
         { path: 'navigation.magneticVariation', value: deg(-10) },
-        { path: 'navigation.headingMagnetic', value: deg(5) },
+        { path: 'navigation.headingMagnetic', value: deg(5) }
       ],
       '$IIHDT,355.0,T*21',
       done

--- a/test/HDTC.ts
+++ b/test/HDTC.ts
@@ -1,10 +1,10 @@
 import { testSequential, testSuppressed } from './testutil'
 
 /**
- * HDMC - HDM sentence calculated from True heading and Variation
+ * HDTC - HDT sentence calculated from Magnetic heading and Variation
  *
- * Derives: headingMagnetic = headingTrue − magneticVariation
- * Produces: $IIHDM,x.x,M*hh
+ * Derives: headingTrue = headingMagnetic + magneticVariation
+ * Produces: $IIHDT,x.x,T*hh
  *
  * Both inputs carry defaults (MISSING sentinel) so the combined stream fires
  * as soon as either path emits.  The guard in the encoder suppresses output
@@ -16,66 +16,66 @@ import { testSequential, testSuppressed } from './testutil'
 
 const deg = (d: number): number => (d * Math.PI) / 180
 
-describe('HDMC', function () {
+describe('HDTC', function () {
   this.timeout(300)
 
   // ── normal computation ───────────────────────────────────────────────────
 
-  it('computes magnetic heading by subtracting variation from true heading', (done) => {
-    // headingTrue=180°, variation=+10° (easterly) → hdgMag = 180 - 10 = 170°
-    // $IIHDM,170.0,M*24
+  it('computes true heading by adding variation to magnetic heading', (done) => {
+    // hdgMag=170°, variation=+10° → hdgTrue = 170 + 10 = 180°
+    // $IIHDT,180.0,T*2B
     testSequential(
-      'HDMC',
+      'HDTC',
       [
         { path: 'navigation.magneticVariation', value: deg(10) },
-        { path: 'navigation.headingTrue', value: Math.PI },
+        { path: 'navigation.headingMagnetic', value: deg(170) },
       ],
-      '$IIHDM,170.0,M*24',
+      '$IIHDT,180.0,T*2B',
       done
     )
   })
 
-  it('wraps into [0, 360) when variation exceeds true heading', (done) => {
-    // headingTrue=5°, variation=+10° → hdgMag = 5 - 10 = -5° → 355°
-    // $IIHDM,355.0,M*21
+  it('wraps into [0, 360) when sum exceeds 360°', (done) => {
+    // hdgMag=355°, variation=+10° → hdgTrue = 355 + 10 = 365° → 5°
+    // $IIHDT,5.0,T*27
     testSequential(
-      'HDMC',
+      'HDTC',
       [
         { path: 'navigation.magneticVariation', value: deg(10) },
-        { path: 'navigation.headingTrue', value: deg(5) },
+        { path: 'navigation.headingMagnetic', value: deg(355) },
       ],
-      '$IIHDM,355.0,M*21',
+      '$IIHDT,5.0,T*27',
       done
     )
   })
 
-  it('wraps into [0, 360) when westerly variation pushes heading above 360°', (done) => {
-    // headingTrue=355°, variation=-10° (westerly) → hdgMag = 355-(-10) = 365° → 5°
-    // $IIHDM,5.0,M*27
+  it('wraps into [0, 360) when westerly variation produces a negative sum', (done) => {
+    // hdgMag=5°, variation=-10° (westerly) → hdgTrue = 5 + (-10) = -5° → 355°
+    // $IIHDT,355.0,T*21
     testSequential(
-      'HDMC',
+      'HDTC',
       [
         { path: 'navigation.magneticVariation', value: deg(-10) },
-        { path: 'navigation.headingTrue', value: deg(355) },
+        { path: 'navigation.headingMagnetic', value: deg(5) },
       ],
-      '$IIHDM,5.0,M*27',
+      '$IIHDT,355.0,T*21',
       done
     )
   })
 
   // ── suppression ──────────────────────────────────────────────────────────
 
-  it('does not emit when only headingTrue is present (variation required)', (done) => {
+  it('does not emit when only headingMagnetic is present (variation required)', (done) => {
     testSuppressed(
-      'HDMC',
-      [{ path: 'navigation.headingTrue', value: Math.PI }],
+      'HDTC',
+      [{ path: 'navigation.headingMagnetic', value: deg(170) }],
       done
     )
   })
 
-  it('does not emit when only magneticVariation is present (headingTrue required)', (done) => {
+  it('does not emit when only magneticVariation is present (headingMagnetic required)', (done) => {
     testSuppressed(
-      'HDMC',
+      'HDTC',
       [{ path: 'navigation.magneticVariation', value: deg(10) }],
       done
     )

--- a/test/testutil.ts
+++ b/test/testutil.ts
@@ -41,7 +41,7 @@ export function createAppWithPlugin(
         const bus = new Bacon.Bus<unknown>()
         streams[p] = bus
         return bus
-      },
+      }
     },
     emittedEvents: [],
     emit: (name: string, value: unknown): void => {
@@ -53,7 +53,7 @@ export function createAppWithPlugin(
     debug: (msg: unknown): void => {
       console.log(msg)
     },
-    getSelfPath: () => null,
+    getSelfPath: () => null
   }
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const plugin = require('../src/index')(app)

--- a/test/testutil.ts
+++ b/test/testutil.ts
@@ -1,3 +1,5 @@
+import * as assert from 'assert'
+
 import * as Bacon from 'baconjs'
 import type { Conversion } from '../src/types/plugin'
 
@@ -39,7 +41,7 @@ export function createAppWithPlugin(
         const bus = new Bacon.Bus<unknown>()
         streams[p] = bus
         return bus
-      }
+      },
     },
     emittedEvents: [],
     emit: (name: string, value: unknown): void => {
@@ -51,7 +53,7 @@ export function createAppWithPlugin(
     debug: (msg: unknown): void => {
       console.log(msg)
     },
-    getSelfPath: () => null
+    getSelfPath: () => null,
   }
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const plugin = require('../src/index')(app)
@@ -66,4 +68,82 @@ export function createAppWithPlugin(
   }
   plugin.start(options)
   return app
+}
+
+/**
+ * Push Signal K values one per event-loop tick (30 ms apart) and assert
+ * the last emitted NMEA sentence after a final 30 ms settle delay.
+ *
+ * Background
+ * ----------
+ * When a sentence encoder carries `defaults` on all keys, the BaconJS
+ * combined stream fires the moment the first path emits.
+ * `debounceImmediate(20)` in index.ts fires immediately on that first
+ * event and suppresses further events within the 20 ms window.
+ *
+ * Consequence: synchronous multi-path pushes are coalesced into only the
+ * FIRST emission; subsequent values are swallowed by the debounce window.
+ *
+ * Solution: push each path after the previous debounce window has expired
+ * (30 ms gap > 20 ms window).  The helper calls `done` after one extra
+ * settle period so the final push is always captured.
+ *
+ * @param sentence  - encoder key used with `createAppWithPlugin`
+ * @param pushes    - ordered list of { path, value } to push sequentially
+ * @param expected  - exact NMEA sentence string expected as the last emission
+ * @param done      - Mocha done callback
+ */
+export function testSequential(
+  sentence: string,
+  pushes: Array<{ path: string; value: number }>,
+  expected: string,
+  done: Mocha.Done
+): void {
+  let last: string | undefined
+  const onEmit = (_event: string, value: unknown): void => {
+    last = value as string
+  }
+  const app = createAppWithPlugin(onEmit, sentence)
+
+  let i = 0
+  function step(): void {
+    if (i < pushes.length) {
+      const { path, value } = pushes[i++]!
+      app.streambundle.getSelfStream(path).push(value)
+      setTimeout(step, 30)
+    } else {
+      setTimeout(() => {
+        assert.strictEqual(last, expected)
+        done()
+      }, 30)
+    }
+  }
+  step()
+}
+
+/**
+ * Assert that a sentence encoder emits nothing after a given set of pushes.
+ *
+ * Useful for testing suppression guards: pushes are made synchronously
+ * (no inter-push delay needed — if even the first push were to trigger
+ * emission we want to detect that), then we wait 60 ms for any deferred
+ * emission to materialise before asserting silence.
+ */
+export function testSuppressed(
+  sentence: string,
+  pushes: Array<{ path: string; value: number }>,
+  done: Mocha.Done
+): void {
+  let emitted = false
+  const onEmit = (): void => {
+    emitted = true
+  }
+  const app = createAppWithPlugin(onEmit, sentence)
+  for (const { path, value } of pushes) {
+    app.streambundle.getSelfStream(path).push(value)
+  }
+  setTimeout(() => {
+    assert.strictEqual(emitted, false)
+    done()
+  }, 60)
 }


### PR DESCRIPTION
WHY:
Heading group sentences have no defaults and provide invalid output when input data is missing
see issue #146 for analysis and details

WHAT:
Heading sentence handling has been updated with defaults where applicable and with tests for missing input data.
Where appropriate the sentence will reply with '' (empty field) for missing data or will not reply at all
when critical data is missing

Tests have been updated to reflest this.

testutil.ts has been upgraded to include the handling of tests where several inputs are pushed sequentially
See full rationale for this in this file.
