### PR TITLE
fix: Update Wind Group message handling (defaults, empty, invalid)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,23 @@ const createPlugin = function (app: SignalKApp): SignalKPlugin {
             }
           }
         )
-          .filter((v) => typeof v !== 'undefined')
+          .filter((v) => {
+            if (typeof v !== 'string') {
+              return false
+            }
+            // Safety net: never put a sentence with a literal "NaN" field on
+            // the wire.  Encoders are expected to render absent/non-finite
+            // values as empty fields, but if one misses a guard the result
+            // would be a corrupt sentence like "$IIMWV,NaN,R,...".  Drop it
+            // here rather than emit garbage downstream.  Match a whole "NaN"
+            // field (delimited by comma/checksum) so a legitimate free-text
+            // field that merely contains those letters is left untouched.
+            if (/(?:^|,)NaN(?:,|\*|$)/.test(v)) {
+              app.debug(`dropping sentence with NaN field: ${v}`)
+              return false
+            }
+            return true
+          })
           .changes()
           .debounceImmediate(20)
 

--- a/src/nmea.ts
+++ b/src/nmea.ts
@@ -155,6 +155,18 @@ export function radsToPositiveDeg(r: number): number {
   return radsToDeg(toPositiveRadians(r))
 }
 
+// Sentinel for an absent NMEA field. Encoders default missing Signal K inputs
+// to MISSING so the combined stream fires as soon as any one path emits, and
+// render a non-finite value as an empty field rather than a fabricated "0.0"
+// or a literal "NaN".
+export const MISSING = '' as const
+export type MaybeNumber = number | null | undefined | typeof MISSING
+
+// Treats null, undefined, NaN, Infinity and non-numeric values as absent.
+export function finiteNum(v: MaybeNumber): v is number {
+  return Number.isFinite(v as number)
+}
+
 export interface FormattedDatetime {
   hours: string
   minutes: string

--- a/src/sentences/MWD.ts
+++ b/src/sentences/MWD.ts
@@ -7,11 +7,33 @@ $IIMWD,x.x,T,x.x,M,x.x,N,x.x,M*hh
  I__I_Wind direction from 0° to 359° true
 
  speed Might be ground speed.
+
+ Signal K inputs and missing-data handling
+ -----------------------------------------
+ environment.wind.directionTrue — true wind direction.
+ navigation.magneticVariation   — used to derive the magnetic direction.
+ environment.wind.speedTrue      — wind speed (m/s).
+
+ All three default to MISSING so the combined stream fires as soon as any
+ one path emits.  A non-finite value (null, NaN, Infinity or a non-numeric
+ value) is treated as absent and produces an empty field rather than a
+ fabricated "0.0" or a literal "NaN":
+   - true direction empty when directionTrue is absent,
+   - magnetic direction empty unless BOTH directionTrue and variation are
+     present (it cannot be derived otherwise),
+   - both speed fields empty when speedTrue is absent.
+ When no field can be populated the sentence is suppressed entirely.
  */
 
 // NMEA0183 Encoder MWD   $IIMWD,279.07,T,90.97,M,9.75,N,5.02,M*74
 import * as nmea from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
+
+const MISSING = '' as const
+type MaybeNumber = number | typeof MISSING
+
+// Treats null, NaN, Infinity and non-numeric values as absent.
+const finiteNum = (v: MaybeNumber): v is number => Number.isFinite(v as number)
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {
@@ -22,21 +44,51 @@ export default function (_app: SignalKApp): SentenceEncoder {
       'navigation.magneticVariation',
       'environment.wind.speedTrue'
     ],
+    defaults: [MISSING, MISSING, MISSING],
     f: function (
-      directionTrue: number,
-      magneticVariation: number,
-      speedTrue: number
-    ): string {
-      const directionMagnetic = nmea.fixAngle(directionTrue - magneticVariation)
+      directionTrue: MaybeNumber,
+      magneticVariation: MaybeNumber,
+      speedTrue: MaybeNumber
+    ): string | undefined {
+      const directionTrueField = finiteNum(directionTrue)
+        ? nmea.radsToPositiveDeg(directionTrue).toFixed(2)
+        : ''
+
+      // The magnetic direction can only be derived when both the true
+      // direction and the variation are available.
+      const directionMagneticField =
+        finiteNum(directionTrue) && finiteNum(magneticVariation)
+          ? nmea
+              .radsToPositiveDeg(
+                nmea.fixAngle(directionTrue - magneticVariation)
+              )
+              .toFixed(2)
+          : ''
+
+      const speedKnotsField = finiteNum(speedTrue)
+        ? nmea.msToKnots(speedTrue).toFixed(2)
+        : ''
+      const speedMsField = finiteNum(speedTrue) ? speedTrue.toFixed(2) : ''
+
+      // Nothing useful to report — suppress rather than emit an empty hull.
+      if (
+        directionTrueField === '' &&
+        directionMagneticField === '' &&
+        speedKnotsField === '' &&
+        speedMsField === ''
+      ) {
+        return undefined
+      }
+
       return nmea.toSentence([
         '$IIMWD',
-        nmea.radsToPositiveDeg(directionTrue).toFixed(2),
+        directionTrueField,
         'T',
-        nmea.radsToPositiveDeg(directionMagnetic).toFixed(2),
+        directionMagneticField,
         'M',
-        nmea.msToKnots(speedTrue).toFixed(2),
+        speedKnotsField,
         'N',
-        speedTrue.toFixed(2),
+        speedMsField,
         'M'
       ])
     }

--- a/src/sentences/MWD.ts
+++ b/src/sentences/MWD.ts
@@ -27,13 +27,8 @@ $IIMWD,x.x,T,x.x,M,x.x,N,x.x,M*hh
 
 // NMEA0183 Encoder MWD   $IIMWD,279.07,T,90.97,M,9.75,N,5.02,M*74
 import * as nmea from '../nmea'
+import { MISSING, finiteNum, type MaybeNumber } from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
-
-const MISSING = '' as const
-type MaybeNumber = number | typeof MISSING
-
-// Treats null, NaN, Infinity and non-numeric values as absent.
-const finiteNum = (v: MaybeNumber): v is number => Number.isFinite(v as number)
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {

--- a/src/sentences/MWVR.ts
+++ b/src/sentences/MWVR.ts
@@ -30,13 +30,8 @@
 
 // NMEA0183 Encoder MWVR   $INMWV,35.01,R,7.9,M,A*30
 import * as nmea from '../nmea'
+import { MISSING, finiteNum, type MaybeNumber } from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
-
-const MISSING = '' as const
-type MaybeNumber = number | typeof MISSING
-
-// Treats null, NaN, Infinity and non-numeric values as absent.
-const finiteNum = (v: MaybeNumber): v is number => Number.isFinite(v as number)
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {

--- a/src/sentences/MWVR.ts
+++ b/src/sentences/MWVR.ts
@@ -15,26 +15,47 @@
       4. Wind Speed Units, K/M/N
       5. Status, A = Data Valid
       6. Checksum
+
+      Signal K inputs and missing-data handling
+      -----------------------------------------
+      environment.wind.angleApparent — apparent wind angle.
+      environment.wind.speedApparent — apparent wind speed (m/s).
+
+      Both default to MISSING so the combined stream fires as soon as either
+      path emits.  A non-finite value (null, NaN, Infinity or a non-numeric
+      value) is treated as absent and produces an empty field rather than a
+      fabricated "0.0" or a literal "NaN".  When neither field can be
+      populated the sentence is suppressed entirely.
     */
 
 // NMEA0183 Encoder MWVR   $INMWV,35.01,R,7.9,M,A*30
 import * as nmea from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
 
+const MISSING = '' as const
+type MaybeNumber = number | typeof MISSING
+
+// Treats null, NaN, Infinity and non-numeric values as absent.
+const finiteNum = (v: MaybeNumber): v is number => Number.isFinite(v as number)
+
 export default function (_app: SignalKApp): SentenceEncoder {
   return {
     sentence: 'MWV',
     title: 'MWV - Apparent Wind heading and speed',
     keys: ['environment.wind.angleApparent', 'environment.wind.speedApparent'],
-    f: function (angle: number, speed: number): string {
-      return nmea.toSentence([
-        '$IIMWV',
-        nmea.radsToPositiveDeg(angle).toFixed(2),
-        'R',
-        speed.toFixed(2),
-        'M',
-        'A'
-      ])
+    defaults: [MISSING, MISSING],
+    f: function (angle: MaybeNumber, speed: MaybeNumber): string | undefined {
+      const angleField = finiteNum(angle)
+        ? nmea.radsToPositiveDeg(angle).toFixed(2)
+        : ''
+      const speedField = finiteNum(speed) ? speed.toFixed(2) : ''
+
+      // Nothing useful to report — suppress rather than emit an empty hull.
+      if (angleField === '' && speedField === '') {
+        return undefined
+      }
+
+      return nmea.toSentence(['$IIMWV', angleField, 'R', speedField, 'M', 'A'])
     }
   }
 }

--- a/src/sentences/MWVT.ts
+++ b/src/sentences/MWVT.ts
@@ -1,23 +1,58 @@
+/*
+      === MWV - Wind Speed and Angle (True) ===
+
+      $--MWV,x.x,a,x.x,a*hh<CR><LF>
+
+      Field Number:
+
+      1. Wind Angle, 0 to 360 degrees
+      2. Reference, R = Relative, T = True
+      3. Wind Speed
+      4. Wind Speed Units, K/M/N
+      5. Status, A = Data Valid
+      6. Checksum
+
+      Signal K inputs and missing-data handling
+      -----------------------------------------
+      environment.wind.angleTrueWater — true wind angle.
+      environment.wind.speedTrue      — true wind speed (m/s).
+
+      Both default to MISSING so the combined stream fires as soon as either
+      path emits.  A non-finite value (null, NaN, Infinity or a non-numeric
+      value) is treated as absent and produces an empty field rather than a
+      fabricated "0.0" or a literal "NaN".  When neither field can be
+      populated the sentence is suppressed entirely.
+    */
+
 // NMEA0183 Encoder MWVTCB   $INMWV,61.44,T,6.04,M,A*0A
 
 import * as nmea from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
+
+const MISSING = '' as const
+type MaybeNumber = number | typeof MISSING
+
+// Treats null, NaN, Infinity and non-numeric values as absent.
+const finiteNum = (v: MaybeNumber): v is number => Number.isFinite(v as number)
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {
     sentence: 'MWV',
     title: 'MWV - True Wind heading and speed',
     keys: ['environment.wind.angleTrueWater', 'environment.wind.speedTrue'],
+    defaults: [MISSING, MISSING],
+    f: function (angle: MaybeNumber, speed: MaybeNumber): string | undefined {
+      const angleField = finiteNum(angle)
+        ? nmea.radsToPositiveDeg(angle).toFixed(2)
+        : ''
+      const speedField = finiteNum(speed) ? speed.toFixed(2) : ''
 
-    f: function (angle: number, speed: number): string {
-      return nmea.toSentence([
-        '$IIMWV',
-        nmea.radsToPositiveDeg(angle).toFixed(2),
-        'T',
-        speed.toFixed(2),
-        'M',
-        'A'
-      ])
+      // Nothing useful to report — suppress rather than emit an empty hull.
+      if (angleField === '' && speedField === '') {
+        return undefined
+      }
+
+      return nmea.toSentence(['$IIMWV', angleField, 'T', speedField, 'M', 'A'])
     }
   }
 }

--- a/src/sentences/MWVT.ts
+++ b/src/sentences/MWVT.ts
@@ -27,13 +27,8 @@
 // NMEA0183 Encoder MWVTCB   $INMWV,61.44,T,6.04,M,A*0A
 
 import * as nmea from '../nmea'
+import { MISSING, finiteNum, type MaybeNumber } from '../nmea'
 import type { SentenceEncoder, SignalKApp } from '../types/plugin'
-
-const MISSING = '' as const
-type MaybeNumber = number | typeof MISSING
-
-// Treats null, NaN, Infinity and non-numeric values as absent.
-const finiteNum = (v: MaybeNumber): v is number => Number.isFinite(v as number)
 
 export default function (_app: SignalKApp): SentenceEncoder {
   return {

--- a/test/MWD.ts
+++ b/test/MWD.ts
@@ -57,6 +57,34 @@ describe('MWD', function () {
     )
   })
 
+  it('produces positive true direction for negative radian input', (done) => {
+    // dirTrue=-10° → 350°, variation=0 → magnetic also 350°.
+    testSequential(
+      'MWD',
+      [
+        { path: 'environment.wind.directionTrue', value: deg(-10) },
+        { path: 'navigation.magneticVariation', value: 0 },
+        { path: 'environment.wind.speedTrue', value: 5 }
+      ],
+      '$IIMWD,350.00,T,350.00,M,9.72,N,5.00,M*4D',
+      done
+    )
+  })
+
+  it('wraps magnetic direction above 360 back into range', (done) => {
+    // dirTrue=355°, variation=-10° (westerly) → raw magnetic = 365° → 5°.
+    testSequential(
+      'MWD',
+      [
+        { path: 'environment.wind.directionTrue', value: deg(355) },
+        { path: 'navigation.magneticVariation', value: deg(-10) },
+        { path: 'environment.wind.speedTrue', value: 5 }
+      ],
+      '$IIMWD,355.00,T,5.00,M,9.72,N,5.00,M*4B',
+      done
+    )
+  })
+
   it('leaves the magnetic field empty when variation is absent', (done) => {
     // Only the true direction is known — magnetic cannot be derived.
     testSequential(

--- a/test/MWD.ts
+++ b/test/MWD.ts
@@ -1,85 +1,103 @@
-import * as assert from 'assert'
+import { testSequential, testSuppressed } from './testutil'
 
-import { createAppWithPlugin } from './testutil'
+/**
+ * MWD - Wind Direction & Speed (relative to North)
+ *
+ * $IIMWD,dirTrue,T,dirMag,M,speedKn,N,speedMs,M*cs
+ *
+ * Field layout:
+ *   0  True wind direction (degrees)
+ *   1  T
+ *   2  Magnetic wind direction (degrees) — derived from true direction and
+ *      magnetic variation; empty unless BOTH are present
+ *   3  M
+ *   4  Wind speed (knots)
+ *   5  N
+ *   6  Wind speed (m/s)
+ *   7  M
+ *
+ * All three Signal K inputs default to MISSING so the combined stream fires
+ * as soon as any one path emits.  Non-finite values are treated as absent
+ * and produce empty fields; when no field can be populated the sentence is
+ * suppressed.
+ *
+ * Checksums generated from the encoder and verified independently.
+ * See test/testutil.ts for the BaconJS timing rationale behind testSequential.
+ */
 
-type AnyApp = ReturnType<typeof createAppWithPlugin>
-
-// Parse the comma-separated body of an NMEA sentence, stripping the checksum.
-function parseSentence(sentence: string): string[] {
-  const star = sentence.indexOf('*')
-  const body = star >= 0 ? sentence.substring(0, star) : sentence
-  return body.split(',')
-}
-
-function pushMWD(
-  app: AnyApp,
-  directionTrueRad: number,
-  variationRad: number,
-  speedTrueMs: number
-): void {
-  app.streambundle
-    .getSelfStream('environment.wind.directionTrue')
-    .push(directionTrueRad)
-  app.streambundle
-    .getSelfStream('navigation.magneticVariation')
-    .push(variationRad)
-  app.streambundle.getSelfStream('environment.wind.speedTrue').push(speedTrueMs)
-}
+const deg = (d: number): number => (d * Math.PI) / 180
 
 describe('MWD', function () {
+  this.timeout(300)
+
   it('emits true and magnetic direction with speed in knots and m/s', (done) => {
-    // directionTrue = 90 deg, variation = 10 deg east
-    // directionMagnetic = 90 - 10 = 80 deg
-    const onEmit = (_event: string, value: unknown): void => {
-      const parts = parseSentence(value as string)
-      assert.equal(parts[0], '$IIMWD')
-      assert.equal(parts[1], '90.00')
-      assert.equal(parts[2], 'T')
-      assert.equal(parts[3], '80.00')
-      assert.equal(parts[4], 'M')
-      assert.equal(parts[6], 'N')
-      assert.equal(parts[8], 'M')
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'MWD')
-    pushMWD(app, Math.PI / 2, (10 * Math.PI) / 180, 5)
+    // dirTrue=90°, variation=10°E → dirMag=80°, speed=5 m/s ≈ 9.72 kn
+    testSequential(
+      'MWD',
+      [
+        { path: 'environment.wind.directionTrue', value: deg(90) },
+        { path: 'navigation.magneticVariation', value: deg(10) },
+        { path: 'environment.wind.speedTrue', value: 5 }
+      ],
+      '$IIMWD,90.00,T,80.00,M,9.72,N,5.00,M*4C',
+      done
+    )
   })
 
-  it('produces positive magnetic direction when variation exceeds true direction', (done) => {
-    // directionTrue = 5 deg, variation = 10 deg east
-    // directionMagnetic = 5 - 10 = -5 deg -> must be 355 deg (not -5)
-    const onEmit = (_event: string, value: unknown): void => {
-      const parts = parseSentence(value as string)
-      assert.equal(parts[1], '5.00')
-      assert.equal(parts[3], '355.00')
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'MWD')
-    pushMWD(app, (5 * Math.PI) / 180, (10 * Math.PI) / 180, 5)
+  it('wraps magnetic direction below zero into 0-359 range', (done) => {
+    // dirTrue=5°, variation=10°E → raw magnetic = -5° → 355°
+    testSequential(
+      'MWD',
+      [
+        { path: 'environment.wind.directionTrue', value: deg(5) },
+        { path: 'navigation.magneticVariation', value: deg(10) }
+      ],
+      '$IIMWD,5.00,T,355.00,M,,N,,M*42',
+      done
+    )
   })
 
-  it('wraps magnetic direction when true near 360 and variation is westerly', (done) => {
-    // directionTrue = 355 deg (6.196 rad), variation = -10 deg (-0.175 rad)
-    // raw magnetic = 355 - (-10) = 365 deg (> 2*PI), fixAngle wraps to 5 deg
-    const onEmit = (_event: string, value: unknown): void => {
-      const parts = parseSentence(value as string)
-      assert.equal(parts[1], '355.00')
-      assert.equal(parts[3], '5.00')
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'MWD')
-    pushMWD(app, (355 * Math.PI) / 180, (-10 * Math.PI) / 180, 5)
+  it('leaves the magnetic field empty when variation is absent', (done) => {
+    // Only the true direction is known — magnetic cannot be derived.
+    testSequential(
+      'MWD',
+      [{ path: 'environment.wind.directionTrue', value: deg(90) }],
+      '$IIMWD,90.00,T,,M,,N,,M*63',
+      done
+    )
   })
 
-  it('produces positive true direction for negative radian input', (done) => {
-    // directionTrue = -10 deg (equivalent to 350 deg), variation = 0
-    const onEmit = (_event: string, value: unknown): void => {
-      const parts = parseSentence(value as string)
-      assert.equal(parts[1], '350.00')
-      assert.equal(parts[3], '350.00')
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'MWD')
-    pushMWD(app, (-10 * Math.PI) / 180, 0, 5)
+  it('leaves both direction fields empty when only speed is present', (done) => {
+    testSequential(
+      'MWD',
+      [{ path: 'environment.wind.speedTrue', value: 5 }],
+      '$IIMWD,,T,,M,9.72,N,5.00,M*4D',
+      done
+    )
+  })
+
+  it('treats a non-finite direction as absent (empty field, not NaN)', (done) => {
+    // directionTrue is NaN → both direction fields empty; speed still emitted.
+    testSequential(
+      'MWD',
+      [
+        { path: 'environment.wind.directionTrue', value: NaN },
+        { path: 'environment.wind.speedTrue', value: 5 }
+      ],
+      '$IIMWD,,T,,M,9.72,N,5.00,M*4D',
+      done
+    )
+  })
+
+  it('suppresses the sentence when every value is non-finite', (done) => {
+    testSuppressed(
+      'MWD',
+      [
+        { path: 'environment.wind.directionTrue', value: NaN },
+        { path: 'navigation.magneticVariation', value: Infinity },
+        { path: 'environment.wind.speedTrue', value: NaN }
+      ],
+      done
+    )
   })
 })

--- a/test/MWV.ts
+++ b/test/MWV.ts
@@ -1,57 +1,135 @@
-import * as assert from 'assert'
+import { testSequential, testSuppressed } from './testutil'
 
-import { createAppWithPlugin } from './testutil'
+/**
+ * MWV - Wind Speed and Angle (relative / true)
+ *
+ * $IIMWV,angle,a,speed,M,A*cs   (a = R relative, T true)
+ *
+ * Both Signal K inputs default to MISSING so the combined stream fires as
+ * soon as either path emits.  Non-finite values are treated as absent and
+ * produce empty fields; when neither field can be populated the sentence is
+ * suppressed.
+ *
+ * Checksums generated from the encoder and verified independently.
+ * See test/testutil.ts for the BaconJS timing rationale behind testSequential.
+ */
 
 describe('MWV relative', function () {
+  this.timeout(300)
+
   it('works with positive angle', (done) => {
-    const onEmit = (_event: string, value: unknown): void => {
-      assert.equal(value, '$IIMWV,180.00,R,2.00,M,A*35')
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'MWVR')
-    app.streambundle
-      .getSelfStream('environment.wind.angleApparent')
-      .push(Math.PI)
-    app.streambundle.getSelfStream('environment.wind.speedApparent').push(2)
+    testSequential(
+      'MWVR',
+      [
+        { path: 'environment.wind.angleApparent', value: Math.PI },
+        { path: 'environment.wind.speedApparent', value: 2 }
+      ],
+      '$IIMWV,180.00,R,2.00,M,A*35',
+      done
+    )
   })
 
   it('works with negative angle', (done) => {
-    const onEmit = (_event: string, value: unknown): void => {
-      assert.equal(value, '$IIMWV,270.00,R,2.00,M,A*39')
-      done()
-    }
-    const app = createAppWithPlugin(onEmit, 'MWVR')
-    app.streambundle
-      .getSelfStream('environment.wind.angleApparent')
-      .push(-Math.PI / 2)
-    app.streambundle.getSelfStream('environment.wind.speedApparent').push(2)
+    testSequential(
+      'MWVR',
+      [
+        { path: 'environment.wind.angleApparent', value: -Math.PI / 2 },
+        { path: 'environment.wind.speedApparent', value: 2 }
+      ],
+      '$IIMWV,270.00,R,2.00,M,A*39',
+      done
+    )
+  })
+
+  it('leaves the speed field empty when speed is absent', (done) => {
+    testSequential(
+      'MWVR',
+      [{ path: 'environment.wind.angleApparent', value: Math.PI }],
+      '$IIMWV,180.00,R,,M,A*29',
+      done
+    )
+  })
+
+  it('treats a non-finite speed as absent (empty field, not NaN)', (done) => {
+    testSequential(
+      'MWVR',
+      [
+        { path: 'environment.wind.angleApparent', value: Math.PI },
+        { path: 'environment.wind.speedApparent', value: NaN }
+      ],
+      '$IIMWV,180.00,R,,M,A*29',
+      done
+    )
+  })
+
+  it('suppresses the sentence when both values are non-finite', (done) => {
+    testSuppressed(
+      'MWVR',
+      [
+        { path: 'environment.wind.angleApparent', value: NaN },
+        { path: 'environment.wind.speedApparent', value: Infinity }
+      ],
+      done
+    )
   })
 })
 
 describe('MWV true', function () {
-  it('works with positive angle', (done) => {
-    const onEmit = (_event: string, value: unknown): void => {
-      assert.equal(value, '$IIMWV,180.00,T,2.00,M,A*33')
-      done()
-    }
+  this.timeout(300)
 
-    const app = createAppWithPlugin(onEmit, 'MWVT')
-    app.streambundle
-      .getSelfStream('environment.wind.angleTrueWater')
-      .push(Math.PI)
-    app.streambundle.getSelfStream('environment.wind.speedTrue').push(2)
+  it('works with positive angle', (done) => {
+    testSequential(
+      'MWVT',
+      [
+        { path: 'environment.wind.angleTrueWater', value: Math.PI },
+        { path: 'environment.wind.speedTrue', value: 2 }
+      ],
+      '$IIMWV,180.00,T,2.00,M,A*33',
+      done
+    )
   })
 
   it('works with negative angle', (done) => {
-    const onEmit = (_event: string, value: unknown): void => {
-      assert.equal(value, '$IIMWV,270.00,T,2.00,M,A*3F')
-      done()
-    }
+    testSequential(
+      'MWVT',
+      [
+        { path: 'environment.wind.angleTrueWater', value: -Math.PI / 2 },
+        { path: 'environment.wind.speedTrue', value: 2 }
+      ],
+      '$IIMWV,270.00,T,2.00,M,A*3F',
+      done
+    )
+  })
 
-    const app = createAppWithPlugin(onEmit, 'MWVT')
-    app.streambundle
-      .getSelfStream('environment.wind.angleTrueWater')
-      .push(-Math.PI / 2)
-    app.streambundle.getSelfStream('environment.wind.speedTrue').push(2)
+  it('leaves the angle field empty when angle is absent', (done) => {
+    testSequential(
+      'MWVT',
+      [{ path: 'environment.wind.speedTrue', value: 2 }],
+      '$IIMWV,,T,2.00,M,A*24',
+      done
+    )
+  })
+
+  it('treats a non-finite angle as absent (empty field, not NaN)', (done) => {
+    testSequential(
+      'MWVT',
+      [
+        { path: 'environment.wind.angleTrueWater', value: NaN },
+        { path: 'environment.wind.speedTrue', value: 2 }
+      ],
+      '$IIMWV,,T,2.00,M,A*24',
+      done
+    )
+  })
+
+  it('suppresses the sentence when both values are non-finite', (done) => {
+    testSuppressed(
+      'MWVT',
+      [
+        { path: 'environment.wind.angleTrueWater', value: Infinity },
+        { path: 'environment.wind.speedTrue', value: NaN }
+      ],
+      done
+    )
   })
 })

--- a/test/nanFilter.ts
+++ b/test/nanFilter.ts
@@ -1,0 +1,40 @@
+import * as assert from 'assert'
+
+import { createAppWithPlugin } from './testutil'
+
+/**
+ * Safety net in src/index.ts: a sentence whose body still contains a literal
+ * "NaN" field must never be emitted, even if an individual encoder forgets to
+ * guard a non-finite input.  Encoders are expected to render absent values as
+ * empty fields, but this is the last line of defence before the wire.
+ *
+ * MTW is used because it has a single key and applies no non-finite guard of
+ * its own (temperature - 273.15 = NaN), so pushing NaN exercises the filter
+ * in index.ts rather than a guard in the encoder.
+ */
+describe('NaN safety-net filter', function () {
+  this.timeout(300)
+
+  it('drops a sentence that would contain a literal NaN field', (done) => {
+    let emitted = false
+    const onEmit = (): void => {
+      emitted = true
+    }
+    const app = createAppWithPlugin(onEmit, 'MTW')
+    app.streambundle.getSelfStream('environment.water.temperature').push(NaN)
+    setTimeout(() => {
+      assert.strictEqual(emitted, false)
+      done()
+    }, 60)
+  })
+
+  it('still emits a valid sentence for finite input', (done) => {
+    const onEmit = (_event: string, value: unknown): void => {
+      assert.strictEqual(value, '$IIMTW,40.0,C*17')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'MTW')
+    // 313.15 K = 40.0 °C
+    app.streambundle.getSelfStream('environment.water.temperature').push(313.15)
+  })
+})


### PR DESCRIPTION
WHY:
Wind group sentences lacked defaults and had no handling for empty/invalid inputs
ref issue #146 for more details

WHAT:
Wind sentence handling has been updated with defaults where applicable and with tests for missing input data.
Where appropriate the sentence will reply with '' (empty field) for missing data or will not reply at all
when critical data is missing.

Tests have been updated to reflect this.
