### PR TITLE
fix(configpanel): render against the admin UI's React instance

### DIFF
--- a/src/configpanel/tsconfig.json
+++ b/src/configpanel/tsconfig.json
@@ -7,7 +7,6 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "target": "ES2022",
-    "jsx": "react-jsx",
     "isolatedModules": true,
     "declaration": false,
     "declarationMap": false,

--- a/test/configPanelBundle.ts
+++ b/test/configPanelBundle.ts
@@ -1,0 +1,112 @@
+/**
+ * Guards the React contract of the Module Federation bundle in `public/`.
+ *
+ * The admin UI renders the configuration panel inside its own React tree
+ * and hands the container its share scope. Signal K has shipped React 16
+ * and React 19 admin UIs across the server versions still in the field,
+ * so the panel has to run on whichever React the host provides. Any copy
+ * of React that ends up inside this bundle breaks that: elements built by
+ * one React major are not recognised by another's reconciler, and hooks
+ * dispatch into a runtime the host never activated. Either way the panel
+ * throws on first render and the admin UI's error boundary replaces the
+ * whole configuration view.
+ *
+ * These assertions run against the built artifacts, so they need
+ * `npm run build:config` to have run first (CI does this before the
+ * suite).
+ */
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const PUBLIC_DIR = path.join(__dirname, '..', 'public')
+
+/** Every emitted JS asset, as `{ name, source }`. */
+function readBundle(): Array<{ name: string; source: string }> {
+  assert.ok(
+    fs.existsSync(PUBLIC_DIR),
+    `${PUBLIC_DIR} is missing - run "npm run build:config" before the tests`
+  )
+  const files = fs
+    .readdirSync(PUBLIC_DIR)
+    .filter((name) => name.endsWith('.js'))
+  assert.ok(files.length > 0, 'no JS assets in public/')
+  return files.map((name) => ({
+    name,
+    source: fs.readFileSync(path.join(PUBLIC_DIR, name), 'utf8')
+  }))
+}
+
+describe('configuration panel bundle', function () {
+  it('bundles no React implementation of its own', () => {
+    // React tags every element it creates with a well-known symbol, and
+    // the name changed between majors ("react.element" through React 18,
+    // "react.transitional.element" in React 19). Finding either string
+    // means a React core or jsx-runtime was bundled rather than shared.
+    const offenders = readBundle()
+      .filter(
+        ({ source }) =>
+          source.includes('react.transitional.element') ||
+          source.includes('react.element')
+      )
+      .map(({ name }) => name)
+    assert.deepEqual(
+      offenders,
+      [],
+      `React element factory bundled into ${offenders.join(', ')}; ` +
+        'the panel must consume React from the host share scope'
+    )
+  })
+
+  it('compiles the panel through React.createElement', () => {
+    // `react/jsx-runtime` is a separate entry point that Module
+    // Federation does not share, so the automatic JSX transform always
+    // bundles the plugin's own copy of it. `"jsx": "react"` in
+    // tsconfig.json keeps JSX on `React.createElement`, which resolves
+    // through the shared `react` module instead.
+    //
+    // Look only at the chunk holding the panel: webpack's own script
+    // loader calls `document.createElement`, so the runtime chunks say
+    // nothing about which JSX transform was used.
+    const panelChunk = readBundle().find(({ source }) =>
+      source.includes('No conversions configured')
+    )
+    assert.ok(panelChunk, 'no chunk contains the panel component')
+    const calls = panelChunk.source.match(/createElement/g) ?? []
+    assert.ok(
+      calls.length > 10,
+      `panel chunk has ${calls.length} createElement calls; ` +
+        'expected the classic JSX runtime'
+    )
+  })
+
+  it('offers no React version to the host share scope', () => {
+    // Webpack's singleton resolution picks the highest registered
+    // version unless the host's entry is already loaded. Registering a
+    // version here is what lets the panel win against an older host and
+    // load a second React. `import: false` in webpack.config.js keeps
+    // the container out of the register call entirely.
+    //
+    // Registration looks like: ("react","19.2.8")
+    const remoteEntry = readBundle().find(
+      ({ name }) => name === 'remoteEntry.js'
+    )
+    assert.ok(remoteEntry, 'remoteEntry.js missing from public/')
+    const registrations = remoteEntry.source.match(/\("react","[0-9][^"]*"/g)
+    assert.equal(
+      registrations,
+      null,
+      `remoteEntry.js registers React ${String(registrations)} in the share scope`
+    )
+  })
+
+  it('exposes the panel under the name the admin UI asks for', () => {
+    const remoteEntry = readBundle().find(
+      ({ name }) => name === 'remoteEntry.js'
+    )!
+    assert.ok(
+      remoteEntry.source.includes('./PluginConfigurationPanel'),
+      'container must expose ./PluginConfigurationPanel'
+    )
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,11 +4,15 @@
     "module": "commonjs",
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM"],
-    // `react-jsx` uses the modern jsx-runtime entry. The webpack
-    // bundle for `src/configpanel/` compiles with a sibling tsconfig
-    // that flips to ESM + bundler resolution; only the JSX transform
-    // is shared. Non-TSX files are unaffected by this setting.
-    "jsx": "react-jsx",
+    // Classic runtime: JSX compiles to `React.createElement` calls that
+    // go through the panel's single `react` import, which Module
+    // Federation resolves to the admin UI's own React instance. The
+    // automatic runtime would instead pull in `react/jsx-runtime`, which
+    // cannot be shared and would build elements the host's React does
+    // not necessarily recognise. The sibling tsconfig under
+    // `src/configpanel/` inherits this so the type gate and the webpack
+    // build cannot drift apart. Non-TSX files are unaffected.
+    "jsx": "react",
 
     "strict": true,
     "noImplicitOverride": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,8 +51,18 @@ module.exports = {
           './src/configpanel/PluginConfigurationPanel'
       },
       shared: {
-        react: { singleton: true, requiredVersion: '^19' },
-        'react-dom': { singleton: true, requiredVersion: '^19' }
+        // The panel renders inside the admin UI's React tree, so it must
+        // use the host's React instance and never carry one of its own.
+        // `import: false` drops the bundled fallback and, with it, the
+        // container's own entry in the share scope; webpack's singleton
+        // resolution would otherwise prefer that higher version over the
+        // host's already-loaded one. `requiredVersion: false` skips the
+        // range check, because the admin UI has shipped React 16 and
+        // React 19 across the server versions in the field and the panel
+        // stays within the hook API both provide. `react-dom` is absent
+        // because the panel renders through the host and never imports
+        // it.
+        react: { singleton: true, requiredVersion: false, import: false }
       }
     })
   ]


### PR DESCRIPTION
Fixes the configuration panel showing `Something went wrong.` on Signal K servers whose admin UI runs React 16 (anything before server 2.24.0, including the 2.19.1 that ships with Venus OS).

## Cause

Two independent problems, both introduced with the custom panel in v1.17.0:

1. `src/configpanel/tsconfig.json` compiled JSX with the automatic runtime, so the bundle imported `react/jsx-runtime`. That entry point is not in webpack's `shared` map and cannot be, so a copy of React 19's element factory was always bundled. Elements it creates carry `Symbol.for("react.transitional.element")`, which React 16 does not recognise.
2. `shared.react` declared `requiredVersion: '^19'` with a bundled fallback, which registers React 19 into the host's share scope. Webpack's singleton resolution prefers the highest registered version whenever the host's entry is not already loaded.

On a React 16 host the panel's first render throws `Objects are not valid as a React child`. `EmbeddedPluginConfigurationForm` has no error boundary, so the route-level one in the admin UI replaces the entire configuration view with `Something went wrong.`.

## Change

- `"jsx": "react"` in `tsconfig.json`, so JSX compiles to `React.createElement` and resolves through the shared `react` module. The panel's sibling tsconfig now inherits the setting instead of restating it, so the type gate and the webpack build cannot drift apart again.
- `shared.react` becomes `{ singleton: true, requiredVersion: false, import: false }`. `import: false` means the container neither bundles nor registers a React of its own, so the host's instance is the only candidate. The version check is dropped because the panel has to run on both React majors currently in the field, and it only uses hooks available in each. `react-dom` is removed; the panel never imports it.

Net effect on the bundle: `public/` drops from 6 files to 3, and no React source is shipped at all.

## Verification

Loaded the built `remoteEntry.js` in jsdom through the same Module Federation handshake `dynamicutilities.js` performs, against both host React majors:

| bundle | React 16.14 host | React 19 host |
| --- | --- | --- |
| before | throws `Objects are not valid as a React child` | renders |
| after | renders | renders |

Both post-fix renders produce an identical tree.

`test/configPanelBundle.ts` locks the invariants in against the built artifacts: no React element factory anywhere in `public/`, the panel chunk compiled through `createElement`, and `remoteEntry.js` offering no React version to the share scope. All three fail against the pre-fix bundle. CI already runs `build:config` before the suite.

Closes #227