### PR TITLE
fix(RMC): skip the sentence when position is null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -180,13 +180,27 @@ const createPlugin = function (app: SignalKApp): SignalKPlugin {
           ? `g${encoder.sentence}`
           : undefined
 
+        // A throwing encoder is called once per combined-stream emission,
+        // which on a live feed means several times a second. Report the
+        // first failure at error level, named after the sentence so the
+        // message is actionable, then route repeats to debug so the
+        // server log stays readable.
+        const encoderName = encoder.sentence ?? encoder.title
+        let failureReported = false
+
         let stream = combineStreamsWith(
           selfStreams,
           function (this: unknown, ...args: unknown[]) {
             try {
               return encoder.f.apply(this, args)
             } catch (e) {
-              console.error((e as Error).message)
+              const message = `${encoderName} encoder failed: ${(e as Error).message}`
+              if (failureReported) {
+                app.debug(message)
+              } else {
+                failureReported = true
+                app.error(message)
+              }
               return undefined
             }
           }
@@ -241,10 +255,7 @@ const createPlugin = function (app: SignalKApp): SignalKPlugin {
       conversions.forEach((conv) => {
         const encoder = plugin.sentences[conv.sentence]
         if (!encoder) {
-          console.error(
-            'sk-to-nmea0183: unknown sentence "%s", skipping',
-            conv.sentence
-          )
+          app.error(`unknown sentence "${conv.sentence}", skipping`)
           return
         }
         mapToNmea(encoder, conv.throttle ?? 0, conv.event)

--- a/src/sentences/GGA.ts
+++ b/src/sentences/GGA.ts
@@ -81,8 +81,11 @@ export default function (_app: SignalKApp): SentenceEncoder {
 
       const datetime = formatDatetime(datetimeInput)
 
+      // A missing position is the normal state while the GPS has no fix,
+      // not a fault: log at debug level so an unfixed receiver does not
+      // fill the server log.
       if (!position) {
-        console.error(`[signalk-to-nmea0183] GGA: no position, not converting`)
+        _app.debug('GGA: skipping emission - no position')
         return undefined
       }
 

--- a/src/sentences/RMC.ts
+++ b/src/sentences/RMC.ts
@@ -50,9 +50,16 @@ export default function (_app: SignalKApp): SentenceEncoder {
       datetime8601: string,
       sog: number | string,
       cog: number | null | undefined,
-      position: Position,
+      position: Position | null | undefined,
       magneticVariation: number | string
-    ): string {
+    ): string | undefined {
+      // Signal K reports navigation.position as null while the GPS has no
+      // fix. Skip the sentence rather than put empty coordinates on the
+      // wire, matching how GLL and GGA handle the same gap.
+      if (!position) {
+        return undefined
+      }
+
       const datetime = formatDatetime(datetime8601)
       let magneticVariationDeg = ''
       let magneticVariationDir = ''

--- a/test/RMC.ts
+++ b/test/RMC.ts
@@ -151,4 +151,39 @@ describe('RMC', function () {
       .getSelfStream('navigation.position')
       .push({ longitude: -122.4208, latitude: 37.82673 })
   })
+
+  // Signal K publishes navigation.position as null while the GPS has no
+  // fix. That is a normal condition at sea, so the encoder must stay
+  // silent rather than throw and have the plugin log the failure.
+  it('does not emit when position is null', (done) => {
+    let emitted = false
+    const onEmit = (): void => {
+      emitted = true
+    }
+    const app = createAppWithPlugin(onEmit, 'RMC')
+    app.streambundle.getSelfStream('navigation.speedOverGround').push('1')
+    app.streambundle.getSelfStream('navigation.courseOverGroundTrue').push('2')
+    app.streambundle.getSelfStream('navigation.position').push(null)
+    setTimeout(() => {
+      assert.equal(emitted, false)
+      assert.deepEqual(app.loggedErrors, [])
+      done()
+    }, 50)
+  })
+
+  it('resumes emitting once a position arrives after a null', (done) => {
+    const onEmit = (_event: string, value: unknown): void => {
+      assert.equal(value, '$GPRMC,,A,0600.0000,N,00500.0000,E,1.9,114.6,,,*14')
+      done()
+    }
+    const app = createAppWithPlugin(onEmit, 'RMC')
+    app.streambundle.getSelfStream('navigation.speedOverGround').push('1')
+    app.streambundle.getSelfStream('navigation.courseOverGroundTrue').push('2')
+    app.streambundle.getSelfStream('navigation.position').push(null)
+    setTimeout(() => {
+      app.streambundle
+        .getSelfStream('navigation.position')
+        .push({ longitude: 5, latitude: 6 })
+    }, 50)
+  })
 })

--- a/test/encoderFailures.ts
+++ b/test/encoderFailures.ts
@@ -1,0 +1,86 @@
+/**
+ * Covers how the plugin reports encoder problems on the server log.
+ *
+ * A sentence encoder runs once per combined-stream emission, so anything
+ * logged unconditionally from the failure path is repeated several times
+ * a second on a live feed. These tests pin the contract: the first
+ * failure is an error naming the sentence, everything after it is debug.
+ */
+import * as assert from 'assert'
+
+import pluginFactory from '../src/index'
+import type { SignalKPlugin } from '../src/types/plugin'
+import { createTestApp } from './testutil'
+
+/** Start the plugin with `sentences` merged into the built-in registry. */
+function startWithEncoders(
+  sentences: SignalKPlugin['sentences'],
+  conversions: Array<{ sentence: string }>
+): ReturnType<typeof createTestApp> {
+  const app = createTestApp(() => {})
+  const plugin = pluginFactory(
+    app as unknown as Parameters<typeof pluginFactory>[0]
+  ) as SignalKPlugin
+  Object.assign(plugin.sentences, sentences)
+  plugin.start({ conversions }, () => {})
+  return app
+}
+
+describe('encoder failure reporting', function () {
+  it('reports the first failure once, naming the sentence', (done) => {
+    const app = startWithEncoders(
+      {
+        BOOM: {
+          sentence: 'BOOM',
+          title: 'BOOM - always throws',
+          keys: ['environment.depth.belowTransducer'],
+          f: (): string => {
+            throw new Error('kaboom')
+          }
+        }
+      },
+      [{ sentence: 'BOOM' }]
+    )
+
+    const stream = app.streambundle.getSelfStream(
+      'environment.depth.belowTransducer'
+    )
+    stream.push(1)
+    stream.push(2)
+    stream.push(3)
+
+    setTimeout(() => {
+      assert.deepEqual(app.loggedErrors, ['BOOM encoder failed: kaboom'])
+      assert.deepEqual(
+        app.debugMessages.filter((m) => m.includes('kaboom')),
+        ['BOOM encoder failed: kaboom', 'BOOM encoder failed: kaboom']
+      )
+      done()
+    }, 50)
+  })
+
+  it('reports an unknown sentence and starts the remaining conversions', (done) => {
+    const app = startWithEncoders({}, [
+      { sentence: 'NOSUCH' },
+      { sentence: 'DBT' }
+    ])
+
+    app.streambundle.getSelfStream('environment.depth.belowTransducer').push(10)
+
+    setTimeout(() => {
+      assert.deepEqual(app.loggedErrors, [
+        'unknown sentence "NOSUCH", skipping'
+      ])
+      assert.ok(
+        app.emittedEvents.some(
+          (e) =>
+            e.name === 'nmea0183out' &&
+            typeof e.value === 'string' &&
+            e.value.startsWith('$IIDBT,')
+        ),
+        'DBT should still be converted'
+      )
+      done()
+    }, 50)
+  })
+})

--- a/test/testutil.ts
+++ b/test/testutil.ts
@@ -16,8 +16,50 @@ interface TestApp {
   }
   emit: (name: string, value: unknown) => void
   debug: (msg: unknown) => void
+  error: (msg: string) => void
   getSelfPath: (path: string) => { value: unknown } | null
   emittedEvents: EmittedEvent[]
+  /** Messages passed to `app.debug`, captured instead of printed. */
+  debugMessages: string[]
+  /** Messages passed to `app.error`; assert on this to pin down log noise. */
+  loggedErrors: string[]
+}
+
+/**
+ * Build a stub Signal K `app` without starting the plugin. Use this when
+ * a test needs to reach the plugin object before `start` (e.g. to inject
+ * an encoder); most tests want `createAppWithPlugin` instead.
+ */
+export function createTestApp(onEmit: OnEmit): TestApp {
+  const streams: Record<string, Bacon.Bus<unknown>> = {}
+  const app: TestApp = {
+    streambundle: {
+      getSelfStream: (p: string): Bacon.Bus<unknown> => {
+        const existing = streams[p]
+        if (existing) return existing
+        const bus = new Bacon.Bus<unknown>()
+        streams[p] = bus
+        return bus
+      }
+    },
+    emittedEvents: [],
+    debugMessages: [],
+    loggedErrors: [],
+    emit: (name: string, value: unknown): void => {
+      app.emittedEvents.push({ name, value })
+      if (name === 'nmea0183out') {
+        onEmit(name, value)
+      }
+    },
+    debug: (msg: unknown): void => {
+      app.debugMessages.push(String(msg))
+    },
+    error: (msg: string): void => {
+      app.loggedErrors.push(msg)
+    },
+    getSelfPath: () => null
+  }
+  return app
 }
 
 /**
@@ -32,29 +74,7 @@ export function createAppWithPlugin(
   onEmit: OnEmit,
   enabledConversion: string | Conversion[] | Record<string, unknown>
 ): TestApp {
-  const streams: Record<string, Bacon.Bus<unknown>> = {}
-  const app: TestApp = {
-    streambundle: {
-      getSelfStream: (p: string): Bacon.Bus<unknown> => {
-        const existing = streams[p]
-        if (existing) return existing
-        const bus = new Bacon.Bus<unknown>()
-        streams[p] = bus
-        return bus
-      }
-    },
-    emittedEvents: [],
-    emit: (name: string, value: unknown): void => {
-      app.emittedEvents.push({ name, value })
-      if (name === 'nmea0183out') {
-        onEmit(name, value)
-      }
-    },
-    debug: (msg: unknown): void => {
-      console.log(msg)
-    },
-    getSelfPath: () => null
-  }
+  const app = createTestApp(onEmit)
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const plugin = require('../src/index')(app)
 


### PR DESCRIPTION
Fixes the server log filling with `Cannot read properties of null (reading 'latitude')`.

## Cause

Signal K publishes `navigation.position` as `null` while the GPS has no fix. `RMC.ts` typed the parameter as a non-nullable `Position` and dereferenced it directly, so the encoder threw on every combined-stream emission. The plugin's catch handler logged the bare message with no sentence name and no stack, which is why the reported lines are impossible to attribute to a sentence.

RMC was the only encoder with this hole: GLL and GGA guard, BWC and RMB use optional chaining. It was also the only sentence with no null-position test.

## Change

- Guard the position in `RMC.ts` and return `undefined`, matching GLL and GGA. Parameter retyped `Position | null | undefined`.
- The encoder failure handler now reports the first failure per sentence through `app.error`, named so the message is actionable (`RMC encoder failed: ...`), and routes repeats to `app.debug`. An encoder that throws once tends to throw on every emission, so the previous unconditional `console.error` is what turned a single bug into a log flood.
- The unknown-sentence notice moves from `console.error` to `app.error` so it reaches the server's log system.
- GGA logged its missing-position skip at error level. An unfixed receiver is a normal condition, so that moves to `app.debug`.

## Tests

- `test/RMC.ts`: silence on a null position with nothing logged, and resuming emission once a fix returns. The first test reproduces the reported failure before the fix.
- `test/encoderFailures.ts`: an injected throwing encoder is reported once at error level and thereafter at debug; an unknown sentence is reported and the remaining conversions still start. Neither path had coverage.
- `test/testutil.ts` gained a `createTestApp` helper that captures `debug` and `error` output instead of printing it, which also quiets the suite's stdout.

Closes #228