### PR TITLE
chore: restore the Node 20.10 engines floor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "webpack-cli": "^7.0.3"
       },
       "engines": {
-        "node": ">=24"
+        "//": "Floor at 20.10 so the Signal K appstore keeps offering updates on Venus OS CerboGX (currently Node 20.18.2). Nothing under src/ uses an API newer than that; the CI matrix stays on 24/26. Raise the floor once Cerbo ships a newer Node.",
+        "node": ">=20.10"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=24"
+    "//": "Floor at 20.10 so the Signal K appstore keeps offering updates on Venus OS CerboGX (currently Node 20.18.2). Nothing under src/ uses an API newer than that; the CI matrix stays on 24/26. Raise the floor once Cerbo ships a newer Node.",
+    "node": ">=20.10"
   },
   "files": [
     "dist",


### PR DESCRIPTION
#201 raised `engines.node` to `>=24`. That PR was opened with a hold note ("This is going to land as soon as Venus OS supports Node v24") but merged before Venus OS caught up, and it has not shipped yet.

Meanwhile #227 and #228 were both reported from a Victron Cerbo GX on Venus OS, running Node 20.18.2. Releasing with `>=24` in place means the Signal K appstore stops offering updates on exactly the platform those fixes were written for.

Nothing in the plugin needs Node 24: the runtime imports no Node builtins at all, and tsc targets ES2022. The floor was a policy choice, not a technical one.

Restores `>=20.10` with a note explaining why it is pinned low. The CI matrix stays on 24/26, so the floor is a compatibility claim rather than a tested one. Raise it again once Cerbo ships a newer Node.